### PR TITLE
Do not use None as key to select rows from a DataFrame.

### DIFF
--- a/sid/contacts.py
+++ b/sid/contacts.py
@@ -78,7 +78,7 @@ def calculate_infections_by_contacts(
     immune = states["immune"].to_numpy(copy=True)
     group_codes = states[[f"group_codes_{cm}" for cm in indexers]].to_numpy()
     infect_probs = np.array(
-        [params.loc[("infection_prob", cm, None), "value"] for cm in indexers]
+        [params.loc[("infection_prob", cm), "value"][0] for cm in indexers]
     )
 
     group_cdfs_list = NumbaList()

--- a/sid/simulate.py
+++ b/sid/simulate.py
@@ -229,6 +229,16 @@ def _check_inputs(
             "params must have the index levels 'category', 'subcategory' and 'name'."
         )
 
+    assert (
+        len(params.loc[("health_system", "icu_limit_relative")]) == 1
+    ), "Only one icu_limit_relative entry allowed."
+    assert (
+        not params.loc["infection_prob"]
+        .index.get_level_values("subcategory")
+        .duplicated()
+        .any()
+    ), "Only one infection probability per contact model allowed."
+
     cd_names = sorted(COUNTDOWNS)
     gb = params.loc[cd_names].groupby(["category", "subcategory"])
     prob_sums = gb["value"].sum()

--- a/sid/update_states.py
+++ b/sid/update_states.py
@@ -42,7 +42,7 @@ def update_states(states, newly_infected, params, seed):
     ]
 
     # Kill people over icu_limit.
-    rel_limit = params.loc[("health_system", "icu_limit_relative", None), "value"]
+    rel_limit = params.loc[("health_system", "icu_limit_relative"), "value"][0]
     abs_limit = rel_limit * len(states)
     need_icu_locs = states.index[states["needs_icu"]]
     if abs_limit < len(need_icu_locs):


### PR DESCRIPTION
### Current behavior

params contains entries that have missing values in some index levels because they don't need three levels. We look these up using

```python 
params.loc[(cat_name, subcat_name, None), "value"]
```
This is problematic because pandas usually converts None and empty strings to `np.nan` and then the code above does not return a float or int but an array. This leads to Errors later on.

### Solution 

Check that entries that should only have one entry only have one entry. 
Afterwards, we can look them up without giving the full index tuple but taking the first element of the array because we know there is only one.

```python
params.loc[(cat_name, subcat_name), "value"][0]
```