### PR TITLE
Solve problems caused by NaN in the index.

### DIFF
--- a/docs/source/explanations/assortative_matching.ipynb
+++ b/docs/source/explanations/assortative_matching.ipynb
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +217,7 @@
     "additional_params = \"\"\"\n",
     "category,subcategory,name,value\n",
     "assortative_matching,meet_people,group,0.1\n",
-    "infection_prob,meet_people,,0.2\n",
+    "infection_prob,meet_people,meet_people,0.2\n",
     "\"\"\"\n",
     "additional_params = pd.read_csv(\n",
     "    io.StringIO(additional_params), index_col=index_columns,\n",

--- a/docs/source/tutorials/infection_probs.csv
+++ b/docs/source/tutorials/infection_probs.csv
@@ -1,3 +1,3 @@
 category,subcategory,name,value,note,source
-infection_prob,close,,0.05,,
-infection_prob,distant,,0.03,,
+infection_prob,close,close,0.05,,
+infection_prob,distant,distant,0.03,,

--- a/docs/test_notebooks.py
+++ b/docs/test_notebooks.py
@@ -4,26 +4,31 @@ from pathlib import Path
 import pytest
 
 
+def find_notebooks():
+    repo_path = Path(__file__).resolve().parent.parent
+    src_path = repo_path / "docs" / "source"
+
+    ipynbs = list(src_path.glob("*/*.ipynb"))
+    # Remove checkpoints.
+    ipynbs = [ipynb for ipynb in ipynbs if ".ipynb_checkpoints" not in ipynb.as_posix()]
+    return ipynbs
+
+
+NOTEBOOKS = find_notebooks()
+
+
 @pytest.mark.optional
-def test_notebooks():
+@pytest.mark.parametrize("nb_path", NOTEBOOKS)
+def test_notebooks(nb_path):
     """Run the simulation notebook.
 
     source: https://nbconvert.readthedocs.io/en/latest/execute_api.html
 
     """
-
-    repo_path = Path(__file__).resolve().parent.parent
-    tutorials_path = repo_path / "docs" / "source" / "tutorials"
-    os.chdir(tutorials_path)
-
-    ipynbs = list(tutorials_path.glob("*.ipynb"))
-    # Remove checkpoints.
-    ipynbs = [ipynb for ipynb in ipynbs if ".ipynb_checkpoints" not in ipynb.as_posix()]
-
     import nbformat
     from nbconvert.preprocessors import ExecutePreprocessor
 
-    for nb_name in ipynbs:
-        with open(nb_name) as f:
-            notebook = nbformat.read(f, as_version=4)
-        ExecutePreprocessor(timeout=600).preprocess(notebook)
+    os.chdir(nb_path.parent)
+    with open(nb_path) as f:
+        notebook = nbformat.read(f, as_version=4)
+    ExecutePreprocessor(timeout=1200).preprocess(notebook)

--- a/sid/contacts.py
+++ b/sid/contacts.py
@@ -78,7 +78,7 @@ def calculate_infections_by_contacts(
     immune = states["immune"].to_numpy(copy=True)
     group_codes = states[[f"group_codes_{cm}" for cm in indexers]].to_numpy()
     infect_probs = np.array(
-        [params.loc[("infection_prob", cm, None), "value"] for cm in indexers]
+        [params.loc[("infection_prob", cm, cm), "value"] for cm in indexers]
     )
 
     group_cdfs_list = NumbaList()

--- a/sid/params.csv
+++ b/sid/params.csv
@@ -1,5 +1,5 @@
 category,subcategory,name,value,note,source
-health_system,icu_limit_relative,,0.0005,Number of ICU beds relative to population size,https://www.dkgev.de/dkg/coronavirus-fakten-und-infos/ (for germany)
+health_system,icu_limit_relative,icu_limit_relative,0.0005,Number of ICU beds relative to population size,https://www.dkgev.de/dkg/coronavirus-fakten-und-infos/ (for germany)
 cd_infectious_true,all,3,1,,https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Steckbrief.html
 cd_infectious_false,all,8,1,This is infectiousness of people who do not get symptoms,https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Steckbrief.html
 cd_immune_false,all,365,1,This is just a guess,https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Steckbrief.html

--- a/sid/tests/test_contacts.py
+++ b/sid/tests/test_contacts.py
@@ -160,7 +160,9 @@ def test_calculate_infections():
     params = pd.DataFrame(
         columns=["value"],
         data=1.0,
-        index=pd.MultiIndex.from_tuples([("infection_prob", "households", None)]),
+        index=pd.MultiIndex.from_tuples(
+            [("infection_prob", "households", "households")]
+        ),
     )
 
     indexers = {"households": create_group_indexer(states, ["households"])}

--- a/sid/tests/test_params.csv
+++ b/sid/tests/test_params.csv
@@ -1,19 +1,19 @@
 category,subcategory,name,value,note,source
-assortative_matching,standard,age_group,0.5
-assortative_matching,standard,region,0.9
-prob_icu_given_symptoms,Under 50,0.003087
-prob_icu_given_symptoms,Over 50,0.045484
-prob_dead_given_icu,Under 50,0.4
-prob_dead_given_icu,Over 50,0.5
-prob_symptoms_given_infection,all,0.75
-cd_infectious_true,all,3,1
-cd_infectious_false,all,8,1
-cd_immune_false,all,365,1
-cd_symptoms_true,all,3,1
-cd_symptoms_false,all,6,1
-cd_needs_icu_true,all,10,1
-cd_dead,all,2,1
-cd_needs_icu_false,all,20,1
-cd_knows_true,all,5,1
-health_system,icu_limit_relative,,0.0005
-infection_prob,standard,,0.05
+assortative_matching,standard,age_group,0.5,,
+assortative_matching,standard,region,0.9,,
+prob_icu_given_symptoms,Under 50,0.003087,,,
+prob_icu_given_symptoms,Over 50,0.045484,,,
+prob_dead_given_icu,Under 50,0.4,,,
+prob_dead_given_icu,Over 50,0.5,,,
+prob_symptoms_given_infection,all,0.75,,,
+cd_infectious_true,all,3,1,,
+cd_infectious_false,all,8,1,,
+cd_immune_false,all,365,1,,
+cd_symptoms_true,all,3,1,,
+cd_symptoms_false,all,6,1,,
+cd_needs_icu_true,all,10,1,,
+cd_dead,all,2,1,,
+cd_needs_icu_false,all,20,1,,
+cd_knows_true,all,5,1,,
+health_system,icu_limit_relative,icu_limit_relative,0.0005,,
+infection_prob,standard,standard,0.05,,

--- a/sid/update_states.py
+++ b/sid/update_states.py
@@ -42,7 +42,9 @@ def update_states(states, newly_infected, params, seed):
     ]
 
     # Kill people over icu_limit.
-    rel_limit = params.loc[("health_system", "icu_limit_relative", None), "value"]
+    rel_limit = params.loc[
+        ("health_system", "icu_limit_relative", "icu_limit_relative"), "value"
+    ]
     abs_limit = rel_limit * len(states)
     need_icu_locs = states.index[states["needs_icu"]]
     if abs_limit < len(need_icu_locs):


### PR DESCRIPTION
### Current behavior

params contains entries that have missing values in some index levels because they don't need three levels. We look these up using

```python 
params.loc[(cat_name, subcat_name, None), "value"]
```
This is problematic because pandas usually converts None and empty strings to `np.nan` and then the code above does not return `float` or `int` but an array. This leads to Errors later on.

### Solution 

Whenever not all index levels are needed, duplicate the earlier index level. So 
`("infection_prob", "meet_people", None)` becomes `("infection_prob", "meet_people", "meet_people").

[x] change code where we look things up
[x] assert that no NaNs are in the supplied params
[x] set the index for the user in case all three columns are present
[  ] run all notebooks as tests.
[  ] make all tests run through. 
