### PR TITLE
Turn off contact models for the dead and people in ICU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ dmypy.json
 
 *.sublime-project
 *.sublime-workspace
+.vscode/
 
 notebooks/
 

--- a/docs/source/reference_guides/contact_models.rst
+++ b/docs/source/reference_guides/contact_models.rst
@@ -70,9 +70,10 @@ For recurrent contact models the matching is fully assortative and exhaustive, i
 individual meets all others who have the exact same value in all ``assort_by``
 variables. In that case the values of the Series are not interpreted quantitatively and
 we just check if they are zero (in which case an individual will not have contacts) or
-larger than zero (in which case she will meet all people in her group). These model
-functions can be used to turn recurrent contact models on and off or to implement that
-school classes only meet on weekdays, make sick individuals stay home, etc..
+larger than zero (in which case she will meet all people in her group who also
+participate in that contact model in that period). These model functions can be used to
+turn recurrent contact models on and off or to implement that school classes only meet
+on weekdays, make sick individuals stay home, etc..
 
 Note that sid automatically implements that dead people and people who need intensive
 care do not have contacts anymore.

--- a/docs/source/reference_guides/contact_models.rst
+++ b/docs/source/reference_guides/contact_models.rst
@@ -74,6 +74,9 @@ larger than zero (in which case she will meet all people in her group). These mo
 functions can be used to turn recurrent contact models on and off or to implement that
 school classes only meet on weekdays, make sick individuals stay home, etc..
 
+Note that sid automatically implements that dead people and people who need intensive
+care do not have contacts anymore.
+
 .. _assort_by:
 
 ``"assort_by"``

--- a/docs/source/reference_guides/states.rst
+++ b/docs/source/reference_guides/states.rst
@@ -101,7 +101,7 @@ We have the following countdowns:
 - **cd_needs_icu_false**:
     How long a person needs intensive care before they recover if a person does not
     die beforehand.
-- **cd_dead**:
+- **cd_dead_true**:
     Time until a person dies, from start of intensive care.
     -1 if a person will survive intensive care of any length.
 - **cd_knows_true**:
@@ -128,7 +128,7 @@ groups look like and where we take the estimates from.
 Other background characteristics you may want to include are:
 
 - variables governing the assortativeness of the matching of individuals, such as
-  region of residence
+  region of residence.
 - individual characteristics that influence how many contacts a person has, such as
-  gender or occupation
-- identifiers for recurrent contact models such ass households or school classes
+  gender or occupation.
+- identifiers for recurrent contact models such as households or school classes.

--- a/sid/contacts.py
+++ b/sid/contacts.py
@@ -26,6 +26,7 @@ def calculate_contacts(contact_models, contact_policies, states, params, date):
         contacts (numpy.ndarray): DataFrame with one column for each contact model.
 
     """
+    # Forbid dead people and icu patients to have contacts. 
     contacts = np.zeros((len(states), len(contact_models)), dtype=DTYPE_N_CONTACTS)
     can_have_contacts = (~states["needs_icu"]) & (~states["dead"])
     participating_contacts = states[can_have_contacts]
@@ -33,7 +34,7 @@ def calculate_contacts(contact_models, contact_policies, states, params, date):
     for i, (model_name, model) in enumerate(contact_models.items()):
         loc = model.get("loc", params.index)
         func = model["model"]
-        cont = func(participating_contacts, params.loc[loc])
+        model_specific_contacts = func(participating_contacts, params.loc[loc])
         if model_name in contact_policies:
             cp = contact_policies[model_name]
             policy_start = pd.to_datetime(cp["start"])

--- a/sid/contacts.py
+++ b/sid/contacts.py
@@ -39,7 +39,6 @@ def calculate_contacts(contact_models, contact_policies, states, params, date):
                 cont *= cp["multiplier"]
         if not model["is_recurrent"]:
             cont = _sum_preserving_round(cont.to_numpy().astype(DTYPE_N_CONTACTS))
-            cont = cont
         columns.append(cont)
 
     contacts = np.column_stack(columns).astype(DTYPE_N_CONTACTS)

--- a/sid/contacts.py
+++ b/sid/contacts.py
@@ -26,7 +26,7 @@ def calculate_contacts(contact_models, contact_policies, states, params, date):
         contacts (numpy.ndarray): DataFrame with one column for each contact model.
 
     """
-    # Forbid dead people and icu patients to have contacts. 
+    # Forbid dead people and icu patients to have contacts.
     contacts = np.zeros((len(states), len(contact_models)), dtype=DTYPE_N_CONTACTS)
     can_have_contacts = (~states["needs_icu"]) & (~states["dead"])
     participating_contacts = states[can_have_contacts]
@@ -42,10 +42,12 @@ def calculate_contacts(contact_models, contact_policies, states, params, date):
             if policy_start <= date <= policy_end and cp["is_active"](
                 participating_contacts
             ):
-                cont *= cp["multiplier"]
+                model_specific_contacts *= cp["multiplier"]
         if not model["is_recurrent"]:
-            cont = _sum_preserving_round(cont.to_numpy().astype(DTYPE_N_CONTACTS))
-        contacts[can_have_contacts, i] = cont
+            model_specific_contacts = _sum_preserving_round(
+                model_specific_contacts.to_numpy().astype(DTYPE_N_CONTACTS)
+            )
+        contacts[can_have_contacts, i] = model_specific_contacts
 
     return contacts
 

--- a/sid/tests/test_contacts.py
+++ b/sid/tests/test_contacts.py
@@ -249,17 +249,15 @@ def test_calculate_contacts_policy_inactive(states_all_alive, contact_models):
         "first_half_meet": {
             "start": "2020-08-01",
             "end": "2020-08-30",
-            "is_active": lambda states: True,
-            "multiplier": 0.0,
+            "is_active": lambda x: True,
+            "multiplier": 0,
         },
     }
     date = pd.Timestamp("2020-09-29")
     params = pd.DataFrame()
     first_half = round(len(states_all_alive) / 2)
-    expected = np.array(
-        [[1, i < first_half] for i in range(len(states_all_alive))],
-        dtype=DTYPE_N_CONTACTS,
-    )
+    expected = np.tile([1, 0], (len(states_all_alive), 1)).astype(DTYPE_N_CONTACTS)
+    expected[:first_half, 1] = 0
     res = calculate_contacts(
         contact_models=contact_models,
         contact_policies=contact_policies,
@@ -276,15 +274,12 @@ def test_calculate_contacts_policy_active(states_all_alive, contact_models):
             "start": "2020-09-01",
             "end": "2020-09-30",
             "is_active": lambda states: True,
-            "multiplier": 0.0,
+            "multiplier": 0,
         },
     }
     date = pd.Timestamp("2020-09-29")
     params = pd.DataFrame()
-    expected = np.array(
-        [[1, 0] for _ in range(len(states_all_alive))],
-        dtype=DTYPE_N_CONTACTS,
-    )
+    expected = np.tile([1, 0], (len(states_all_alive), 1)).astype(DTYPE_N_CONTACTS)
     res = calculate_contacts(
         contact_models=contact_models,
         contact_policies=contact_policies,
@@ -297,9 +292,10 @@ def test_calculate_contacts_policy_active(states_all_alive, contact_models):
 
 @pytest.fixture
 def states_with_dead(states_all_alive):
-    states_all_alive.loc[:2, "dead"] = [True, False, True]
-    states_all_alive.loc[5:, "needs_icu"] = [True, False, True]
-    return states_all_alive
+    states_with_dead = states_all_alive.copy()
+    states_with_dead.loc[:2, "dead"] = [True, False, True]
+    states_with_dead.loc[5:, "needs_icu"] = [True, False, True]
+    return states_with_dead
 
 
 def test_calculate_contacts_with_dead(states_with_dead, contact_models):

--- a/sid/tests/test_contacts.py
+++ b/sid/tests/test_contacts.py
@@ -257,7 +257,7 @@ def test_calculate_contacts_policy_inactive(states_all_alive, contact_models):
     params = pd.DataFrame()
     first_half = round(len(states_all_alive) / 2)
     expected = np.tile([1, 0], (len(states_all_alive), 1)).astype(DTYPE_N_CONTACTS)
-    expected[:first_half, 1] = 0
+    expected[:first_half, 1] = 1
     res = calculate_contacts(
         contact_models=contact_models,
         contact_policies=contact_policies,

--- a/sid/tests/test_contacts.py
+++ b/sid/tests/test_contacts.py
@@ -5,7 +5,9 @@ import pandas as pd
 import pytest
 from numba.typed import List as NumbaList
 
+from sid.config import DTYPE_N_CONTACTS
 from sid.contacts import _calculate_infections_by_contacts_numba
+from sid.contacts import calculate_contacts
 from sid.contacts import calculate_infections_by_contacts
 from sid.contacts import create_group_indexer
 
@@ -184,3 +186,102 @@ def test_calculate_infections():
     assert calc_infected.equals(exp_infected)
     assert calc_states["n_has_infected"].astype(np.int32).equals(exp_infection_counter)
     assert calc_states["immune"].equals(exp_immune)
+
+
+# =====================================================================================
+# calculate_contacts
+# =====================================================================================
+
+
+@pytest.fixture
+def contact_models():
+    def meet_one(states, params):
+        return pd.Series(1, index=states.index)
+
+    def first_half_meet(states, params):
+        n_contacts = pd.Series(0, index=states.index)
+        first_half = round(len(states) / 2)
+        n_contacts[:first_half] = 1
+        return n_contacts
+
+    contact_models = {
+        "meet_one": {
+            "model": meet_one,
+            "is_recurrent": False,
+        },
+        "first_half_meet": {
+            "model": first_half_meet,
+            "is_recurrent": False,
+        },
+    }
+    return contact_models
+
+
+def test_calculate_contacts_no_policy(initial_states, contact_models):
+    contact_policies = {}
+    date = pd.Timestamp("2020-09-29")
+    params = pd.DataFrame()
+    first_half = round(len(initial_states) / 2)
+    expected = np.array(
+        [[1, i < first_half] for i in range(len(initial_states))],
+        dtype=DTYPE_N_CONTACTS,
+    )
+    res = calculate_contacts(
+        contact_models=contact_models,
+        contact_policies=contact_policies,
+        states=initial_states,
+        params=params,
+        date=date,
+    )
+    np.testing.assert_array_equal(expected, res)
+
+
+def test_calculate_contacts_policy_inactive(initial_states, contact_models):
+    contact_policies = {
+        "first_half_meet": {
+            "start": "2020-08-01",
+            "end": "2020-08-30",
+            "is_active": lambda states: True,
+            "multiplier": 0.0,
+        },
+    }
+    date = pd.Timestamp("2020-09-29")
+    params = pd.DataFrame()
+    first_half = round(len(initial_states) / 2)
+    expected = np.array(
+        [[1, i < first_half] for i in range(len(initial_states))],
+        dtype=DTYPE_N_CONTACTS,
+    )
+    res = calculate_contacts(
+        contact_models=contact_models,
+        contact_policies=contact_policies,
+        states=initial_states,
+        params=params,
+        date=date,
+    )
+    np.testing.assert_array_equal(expected, res)
+
+
+def test_calculate_contacts_policy_active(initial_states, contact_models):
+    contact_policies = {
+        "first_half_meet": {
+            "start": "2020-09-01",
+            "end": "2020-09-30",
+            "is_active": lambda states: True,
+            "multiplier": 0.0,
+        },
+    }
+    date = pd.Timestamp("2020-09-29")
+    params = pd.DataFrame()
+    expected = np.array(
+        [[1, 0] for _ in range(len(initial_states))],
+        dtype=DTYPE_N_CONTACTS,
+    )
+    res = calculate_contacts(
+        contact_models=contact_models,
+        contact_policies=contact_policies,
+        states=initial_states,
+        params=params,
+        date=date,
+    )
+    np.testing.assert_array_equal(expected, res)


### PR DESCRIPTION
### Current behavior

Currently we still calculate contacts for the people who are dead or in ICU. They also still meet people and can infect them.

### Desired behavior

Neither the dead nor people should still have contacts. 

### Solution / Implementation

Only calculate the contacts for individuals that are alive and not in the ICU. 
To do so only pass the section of states to the contact functions where people are neither 
dead nor in the ICU.

### Todos

- [x] Add tests for the current `calculate_contacts` function
- [x] Pass only the relevant part of states to the contact functions
- [x] Expand contacts to the full size.
- [x] Review whether the documentation needs to be updated.
- [x] Test that the right contacts are set to zero.
