### PR TITLE
Enforce fastparquet.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,11 +48,11 @@ repos:
             Pygments,
         ]
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.3.5
+  rev: 0.3.6
   hooks:
-    - id: nbqa-black
-    - id: nbqa-pyupgrade
-    - id: nbqa-isort
+    -   id: nbqa-black
+    -   id: nbqa-pyupgrade
+    -   id: nbqa-isort
 -   repo: https://github.com/PyCQA/doc8
     rev: 0.9.0a1
     hooks:

--- a/docs/source/reference_guides/policies.rst
+++ b/docs/source/reference_guides/policies.rst
@@ -31,7 +31,6 @@ when ``states`` fulfills some condition. Here is an example:
         }
     }
 
-
 ``"work_close"`` is the name of the contact model the policies refers to. ``"start"``
 and ``"end"`` define the time period in dates when the policy is active. They are
 optional. ``"multiplier"`` will be multiplied with the number of contacts. It is no

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -585,7 +585,7 @@ def _dump_periodic_states(states, output_directory, date, debug):
         useless_columns = USELESS_COLUMNS + group_codes
         states = states.drop(columns=useless_columns)
 
-    states.to_parquet(output_directory / f"{date.date()}.parquet")
+    states.to_parquet(output_directory / f"{date.date()}.parquet", engine="fastparquet")
 
 
 def _return_dask_dataframe(output_directory, categoricals):
@@ -598,4 +598,6 @@ def _return_dask_dataframe(output_directory, categoricals):
         df (dask.dataframe): A dask DataFrame which contains the simulation results.
 
     """
-    return dd.read_parquet(output_directory, categories=categoricals)
+    return dd.read_parquet(
+        output_directory, categories=categoricals, engine="fastparquet"
+    )

--- a/src/sid/visualize_simulation_results.py
+++ b/src/sid/visualize_simulation_results.py
@@ -123,7 +123,7 @@ def _load_data(df_or_path, keep_vars, i):
         df = df_or_path[keep_vars]
         df_name = i
     elif isinstance(df_or_path, Path):
-        df = dd.read_parquet(df_or_path)[keep_vars].compute()
+        df = dd.read_parquet(df_or_path, engine="fastparquet")[keep_vars].compute()
         df_name = df_or_path.stem
     else:
         raise NotImplementedError

--- a/tests/test_visualize_simulation_results.py
+++ b/tests/test_visualize_simulation_results.py
@@ -36,7 +36,7 @@ def test_create_folders(tmp_path):
 def test_load_data_path():
     path = Path(__file__).resolve().parent / "simulation_results" / "1.parquet"
     expected_name = "1"
-    expected_df = pd.read_parquet(path)[KEEP_VARS]
+    expected_df = pd.read_parquet(path, engine="fastparquet")[KEEP_VARS]
     name, df = _load_data(path, keep_vars=KEEP_VARS, i=100)
     assert expected_name == name
     pd.testing.assert_frame_equal(expected_df, df)
@@ -46,7 +46,7 @@ def test_load_data_path():
 def test_load_data_df():
     path = Path(__file__).resolve().parent / "simulation_results" / "1.parquet"
     input_df = pd.read_parquet(path)
-    expected_df = pd.read_parquet(path)[KEEP_VARS]
+    expected_df = pd.read_parquet(path, engine="fastparquet")[KEEP_VARS]
     name, df = _load_data(input_df, keep_vars=KEEP_VARS, i=100)
     assert name == 100
     pd.testing.assert_frame_equal(expected_df, df)


### PR DESCRIPTION
### Current behavior

pandas and dask use pyarrow instead of fastparquet as the default parquet backend. This introduces some problems since fastparquet has better support for native pandas dtypes like datetime and categoricals.

### Desired behavior

- Enforce that fastparquet is used.
- Users should not make the same mistake when they want to work with sids data. I am not sure how we can enforce it for them as well besides via providing our own reader and writer.
- Should we add a note to the docs?

### Solution / Implementation

- Add ``engine="fastparquet"`` where possible.