### PR TITLE
Make sid 3 times faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ docs/source/_generated/
 # sid
 .sid/
 src/__init__.py
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,3 @@ docs/source/_generated/
 # sid
 .sid/
 src/__init__.py
-
-

--- a/environment.yml
+++ b/environment.yml
@@ -37,11 +37,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-autoapi
 
-  # for bokeh png export
-  - selenium
-  - geckodriver
-  - firefox
-
   # Jupyter Lab Formatter
   - black
   - jupyterlab_code_formatter

--- a/src/sid/config.py
+++ b/src/sid/config.py
@@ -38,31 +38,20 @@ INDEX_NAMES = ["category", "subcategory", "name"]
 
 ROOT_DIR = Path(__file__).parent
 
-USELESS_COLUMNS = [
-    # General countdowns.
-    "cd_infectious_true",
-    "cd_immune_false",
-    "cd_symptoms_true",
-    "cd_symptoms_false",
-    "cd_needs_icu_true",
-    "cd_dead_true",
-    "cd_needs_icu_false",
-    "cd_immune_false_draws",
-    "cd_symptoms_true_draws",
-    "cd_needs_icu_true_draws",
-    "cd_dead_true_draws",
-    "cd_symptoms_false_draws",
-    "cd_needs_icu_false_draws",
-    "cd_infectious_true_draws",
-    "cd_infectious_false_draws",
-    # Countdowns related to testing.
-    "cd_received_test_result_true_draws",
-    "cd_knows_immune_false",
-    "cd_knows_infectious_false",
-    # Others.
-    "demands_test",
-    "allocated_test",
-    "to_be_processed_test",
-    "pending_test_date",
-    "pending_test_period",
-]
+SAVED_COLUMNS = {
+    "initial_states": True,
+    "disease_states": True,
+    "testing_states": False,
+    "countdowns": ["cd_infectious_false"],
+    "contacts": False,
+    "countdown_draws": False,
+    "group_codes": False,
+    "other": ["n_has_infected"],
+}
+
+
+
+OPTIONAL_STATE_COLUMNS = {
+    "contacts": False,
+    "reason_for_infection": False,
+}

--- a/src/sid/config.py
+++ b/src/sid/config.py
@@ -50,7 +50,6 @@ SAVED_COLUMNS = {
 }
 
 
-
 OPTIONAL_STATE_COLUMNS = {
     "contacts": False,
     "reason_for_infection": False,

--- a/src/sid/contacts.py
+++ b/src/sid/contacts.py
@@ -110,10 +110,8 @@ def calculate_infections_by_contacts(
         indexers_list.append(ind)
 
     np.random.seed(next(seed))
-    loop_entries = _get_loop_entries(len(states), len(indexers))
 
-    indices = np.random.choice(len(loop_entries), replace=False, size=len(loop_entries))
-    loop_order = loop_entries[indices]
+    loop_order = _get_shuffled_loop_entries(len(states), len(indexers), next(seed))
 
     (
         infected,
@@ -148,21 +146,36 @@ def calculate_infections_by_contacts(
 
 
 @nb.njit
-def _get_loop_entries(n_states, n_contact_models):
+def _get_shuffled_loop_entries(n_states, n_contact_models, seed, n_model_orders=1000):
     """Create an array of loop entries.
 
-    Examples:
-        >>> _get_loop_entries(2, 2)
-        array([[0, 0],
-               [0, 1],
-               [1, 0],
-               [1, 1]]...
+    We save the loop entries of the following loop in shuffled order:
 
-    """
-    res = np.empty((n_states * n_contact_models, 2), dtype=np.int64)
-    counter = 0
     for i in range(n_states):
         for j in range(n_contact_models):
+            pass
+
+    The loop entries are stored in an array with n_states * n_contact_model rows
+    and two columns. The first column contains the i, the second the j elements.
+
+    Achieving complete randomness would require us to first store all loop entries
+    in an array and then shuffle it. However, this would be very slow. Instead
+    we loop over states in random order and cycle through previously
+
+    """
+    np.random.seed(seed)
+    res = np.empty((n_states * n_contact_models, 2), dtype=np.int64)
+    shuffled_state_indices = np.random.choice(n_states, replace=False, size=n_states)
+
+    # create random permutations of the model orders
+    model_orders = np.zeros((n_model_orders, n_contact_models))
+    for m in range(n_model_orders):
+        model_orders[m] = np.random.choice(n_contact_models, replace=False, size=n_contact_models)
+
+    counter = 0
+
+    for i in shuffled_state_indices:
+        for j in model_orders[i % n_model_orders]:
             res[counter, 0] = i
             res[counter, 1] = j
             counter += 1

--- a/src/sid/contacts.py
+++ b/src/sid/contacts.py
@@ -170,7 +170,9 @@ def _get_shuffled_loop_entries(n_states, n_contact_models, seed, n_model_orders=
     # create random permutations of the model orders
     model_orders = np.zeros((n_model_orders, n_contact_models))
     for m in range(n_model_orders):
-        model_orders[m] = np.random.choice(n_contact_models, replace=False, size=n_contact_models)
+        model_orders[m] = np.random.choice(
+            n_contact_models, replace=False, size=n_contact_models
+        )
 
     counter = 0
 

--- a/src/sid/events.py
+++ b/src/sid/events.py
@@ -19,12 +19,15 @@ def calculate_infections_by_events(states, params, events):
 
     """
     infections_by_events = pd.DataFrame()
-    for name, event in events.items():
-        loc = event.get("loc", params.index)
-        func = event["model"]
+    if events:
+        for name, event in events.items():
+            loc = event.get("loc", params.index)
+            func = event["model"]
 
-        infections_by_events[name] = func(states, params.loc[loc])
+            infections_by_events[name] = func(states, params.loc[loc])
 
-    newly_infected_events = infections_by_events.any(axis=1)
+        newly_infected_events = infections_by_events.any(axis=1)
+    else:
+        newly_infected_events = pd.Series(False, index=states.index)
 
     return newly_infected_events

--- a/src/sid/events.py
+++ b/src/sid/events.py
@@ -18,16 +18,14 @@ def calculate_infections_by_events(states, params, events):
             boolean. `True` marks individuals infected by an event.
 
     """
-    infections_by_events = pd.DataFrame()
-    if events:
-        for name, event in events.items():
-            loc = event.get("loc", params.index)
-            func = event["model"]
+    infections_by_events = pd.DataFrame(index=states.index)
 
-            infections_by_events[name] = func(states, params.loc[loc])
+    for name, event in events.items():
+        loc = event.get("loc", params.index)
+        func = event["model"]
 
-        newly_infected_events = infections_by_events.any(axis=1)
-    else:
-        newly_infected_events = pd.Series(False, index=states.index)
+        infections_by_events[name] = func(states, params.loc[loc])
+
+    newly_infected_events = infections_by_events.any(axis=1)
 
     return newly_infected_events

--- a/src/sid/update_states.py
+++ b/src/sid/update_states.py
@@ -58,8 +58,10 @@ def update_states(
     newly_infected_events = newly_infected_events.to_numpy()
     channel[newly_infected_contacts & ~newly_infected_events] = 1
     channel[newly_infected_events & ~newly_infected_contacts] = 2
-    states["newly_infected_reason"] = pd.Categorical(
-        channel, categories=[0, 1, 2]).rename_categories(labels)
+    # set categories is necessary in case one of the categories was not present in the
+    # data. Setting them via set_categories is much faster than passing them into
+    # pd.Categorical directly
+    states["newly_infected_reason"] = pd.Categorical(channel).set_categories([0, 1, 2]).rename_categories(labels)
 
     # Update states with new infections and add corresponding countdowns.
     locs = states.query("newly_infected").index

--- a/src/sid/update_states.py
+++ b/src/sid/update_states.py
@@ -66,10 +66,12 @@ def update_states(
         newly_infected_events = newly_infected_events.to_numpy()
         channel[newly_infected_contacts & ~newly_infected_events] = 1
         channel[newly_infected_events & ~newly_infected_contacts] = 2
-        # set categories is necessary in case one of the categories was not present in the
-        # data. Setting them via set_categories is much faster than passing them into
-        # pd.Categorical directly
-        states["newly_infected_reason"] = pd.Categorical(channel).set_categories([0, 1, 2]).rename_categories(labels)
+        # set categories is necessary in case one of the categories was not present in
+        # the data. Setting them via set_categories is much faster than passing them
+        # into pd.Categorical directly
+        states["newly_infected_reason"] = (
+            pd.Categorical(channel).set_categories([0, 1, 2]).rename_categories(labels)
+        )
 
     # Update states with new infections and add corresponding countdowns.
     locs = states.query("newly_infected").index

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -8,7 +8,6 @@ from numba.typed import List as NumbaList
 from numpy.testing import assert_array_equal
 from sid.config import DTYPE_N_CONTACTS
 from sid.contacts import _calculate_infections_by_contacts_numba
-from sid.contacts import _get_loop_entries
 from sid.contacts import _reduce_contacts_with_infection_probs
 from sid.contacts import calculate_contacts
 from sid.contacts import calculate_infections_by_contacts
@@ -494,12 +493,6 @@ def test_calculate_contacts_with_dead(states_with_dead, contact_models):
         date=date,
     )
     np.testing.assert_array_equal(expected, res)
-
-
-def test_get_loop_entries():
-    calculated = _get_loop_entries(10, 15)
-    expected = np.array(list(itertools.product(range(10), range(15)))).astype(int)
-    assert_array_equal(calculated, expected)
 
 
 def test_reduce_contacts_with_infection_prob_one():

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -22,8 +22,7 @@ CONTACT_MODELS = {
 }
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_simple_run(params, initial_states, tmp_path, debug):
+def test_simple_run(params, initial_states, tmp_path):
     initial_infections = pd.Series(index=initial_states.index, data=False)
     initial_infections.iloc[0] = True
 
@@ -33,7 +32,6 @@ def test_simple_run(params, initial_states, tmp_path, debug):
         initial_infections,
         CONTACT_MODELS,
         path=tmp_path,
-        debug=debug,
     )
 
     df = simulate(params)


### PR DESCRIPTION
# Description

- baseline: 240 Seconds
- reverse loop order when we calculate infections from recurrent contacts: 200 seconds
- faster shuffling of individual-contact_model combinations: 144 seconds
- faster drawing of random contacts in non-recurrent contact models: 126 seconds
- improvements in update states: 102 seconds
- save reduced dataset and further improvements to update_states: 76 seconds

@tobiasraabe, I suggest you go along this list when making the review. 
