### PR TITLE
Implement more flexible policies

### DIFF
--- a/docs/source/reference_guides/policies.rst
+++ b/docs/source/reference_guides/policies.rst
@@ -15,6 +15,7 @@ contact models in a separate, specialized `contact_policies` dictionary.
 
 The contact policies are a nested dictionary, mapping the policy's name
 to its specification. You can choose any name you wish.
+
 The specification must contain an `affected_contact_model` entry,
 a `policy` entry and provide when the policy is active.
 The `affected_contact_model` gives the name of the contact model
@@ -23,6 +24,8 @@ whose output, the `contacts`
 will be modified while the policy is active.
 The `policy` entry is either a float or a function.
 If it is a float, the contacts are simply multiplied with the this number.
+For non-recurrent contact models we will round the results
+for you to have the wanted reduction on average.
 If it is a function, it should take the
 `states`, `contacts` and `params` as inputs and return
 a modified `contacts` Series.

--- a/docs/source/reference_guides/testing.rst
+++ b/docs/source/reference_guides/testing.rst
@@ -3,6 +3,8 @@
 Testing
 =======
 
+For an introduction to specify testing, have a look at the `testing tutorial <../tutorials/how_to_test.ipynb>`_
+
 
 .. _testing_demand_models:
 

--- a/docs/source/tutorials/how_to_specify_policies.ipynb
+++ b/docs/source/tutorials/how_to_specify_policies.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to Specify Policies\n",
+    "\n",
+    "In SID we can implement nearly any type of policy as a modification of the `contact models`.\n",
+    "However, to keep things separable and modular, policies can also specified outside the\n",
+    "contact models in a seperate, specialized ``contact_policies`` dictionary.\n",
+    "\n",
+    "Here we showcase some abilities of `contact_policies`, building from easier to more involved policies.\n",
+    "\n",
+    "Let's assume that we have three contact models, `school`, `work` and `other` and want to implement a lockdown from the 22nd of March to the 20th of April.\n",
+    "\n",
+    "Let's start with defining our `contact_model` functions and then define our `contact_models`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def attends_school(states):\n",
+    "    \"\"\"All children with a school class go to school\"\"\"\n",
+    "    date = get_date(states)\n",
+    "    day = date.day_name()\n",
+    "    if day in [\"Saturday\", \"Sunday\"]:\n",
+    "        return pd.Series(data=0, index=states.index)\n",
+    "    else:\n",
+    "        return states[\"school_class_id\"] > 0\n",
+    "\n",
+    "\n",
+    "def work_contacts(states):\n",
+    "    \"\"\"On weekdays every worker meets between 0 and 10 people.\"\"\"\n",
+    "    contacts = pd.Series(data=0, index=states.index)\n",
+    "    date = get_date(states)\n",
+    "    day = date.day_name()\n",
+    "    if day in [\"Saturday\", \"Sunday\"]:\n",
+    "        return contacts\n",
+    "    else:\n",
+    "        workers = states[states[\"occupation\"] == \"working\"].index\n",
+    "        contacts[workers] = np.random.randint(low=0, high=10, size=len(workers))\n",
+    "        return contacts\n",
+    "\n",
+    "\n",
+    "def n_strangers_to_meet(states):\n",
+    "    \"\"\"Every day everyone meets two strangers.\"\"\"\n",
+    "    return pd.Series(2, index=states.index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contact_models = {\n",
+    "    \"school\": {\n",
+    "        \"is_recurrent\": True,\n",
+    "        \"model\": attends_school,\n",
+    "        \"assort_by\": [\"school_class_id\"],\n",
+    "    },\n",
+    "    \"work\": {\n",
+    "        \"is_recurrent\": False,\n",
+    "        \"model\": work_contacts,\n",
+    "    },\n",
+    "    \"other\": {\n",
+    "        \"is_recurrent\": False,\n",
+    "        \"model\": n_strangers_to_meet,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To implement the most basic lockdown, let's close schools and businesses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basic_lockdown = {\n",
+    "    \"basic_lockdown_school\": {\n",
+    "        \"affected_contact_model\": \"school\",\n",
+    "        \"policy\": 0,\n",
+    "        \"start\": \"2020-03-22\",\n",
+    "        \"end\": \"2020-04-20\",\n",
+    "    },\n",
+    "    \"basic_lockdown_work\": {\n",
+    "        \"affected_contact_model\": \"work\",\n",
+    "        \"policy\": 0,\n",
+    "        \"start\": \"2020-03-22\",\n",
+    "        \"end\": \"2020-04-20\",\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's say our states identify people working in systemically relevant\n",
+    "occupations (grocery stores, hospitals ...) and we want to implement\n",
+    "that they continue to work. We can do this by providing a policy function as the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def only_systemically_relevnt_workers_work(states, contacts, params):\n",
+    "    essential = states[\"systemically_relevant\"]\n",
+    "    return contacts.where(essential, 0)\n",
+    "\n",
+    "\n",
+    "lockdown_for_non_essential_workers = {\n",
+    "    \"basic_lockdown_school\": {\n",
+    "        \"affected_contact_model\": \"school\",\n",
+    "        \"policy\": 0,\n",
+    "        \"start\": \"2020-03-22\",\n",
+    "        \"end\": \"2020-04-20\",\n",
+    "    },\n",
+    "    \"only_essentials_work\": {\n",
+    "        \"affected_contact_model\": \"work\",\n",
+    "        \"policy\": only_systemically_relevnt_workers_work,\n",
+    "        \"start\": \"2020-03-22\",\n",
+    "        \"end\": \"2020-04-20\",\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, we might place a state wide shelter in place order if the incidence surpasses 100 cases per 100 000 inhabitants. In that case we want to reduce the `other` contact model to have no one meet anyone. \n",
+    "\n",
+    "One way to specify this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def incidence_above_threshold(states, threshold):\n",
+    "    return states[\"knows_infectious\"].mean() > threshold\n",
+    "\n",
+    "\n",
+    "lockdown_with_shelter_in_place = {\n",
+    "    \"basic_lockdown_school\": {\n",
+    "        \"affected_contact_model\": \"school\",\n",
+    "        \"policy\": 0.0,\n",
+    "        \"start\": \"2020-03-22\",\n",
+    "        \"end\": \"2020-04-20\",\n",
+    "    },\n",
+    "    \"only_essentials_work\": {\n",
+    "        \"affected_contact_model\": \"work\",\n",
+    "        \"policy\": only_systemically_relevnt_workers_work,\n",
+    "        \"start\": \"2020-03-22\",\n",
+    "        \"end\": \"2020-04-20\",\n",
+    "    },\n",
+    "    \"shelter_in_place\": {\n",
+    "        \"affected_contact_model\": \"other\",\n",
+    "        \"policy\": 0.0,\n",
+    "        \"start\": \"2020-03-22\",\n",
+    "        \"end\": \"2020-04-20\",\n",
+    "        \"is_active\": partial(\n",
+    "            incidence_above_threshold,\n",
+    "            threshold=100 / 100000,\n",
+    "        ),\n",
+    "    },\n",
+    "}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -8,4 +8,5 @@ simple model and show you how to use sid to simulate your own model.
    :maxdepth: 1
 
    how_to_simulate
+   how_to_specify_policies
    how_to_test

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -175,7 +175,7 @@ def _simulate(
         duration (dict): Duration is a dictionary containing kwargs for
             :func:`pandas.date_range`.
         events (dict): Dictionary of events which cause infections.
-        contact_policies (dict): Dict of dicts with contact. See :ref:`policies`.
+        contact_policies (dict): Dict of dicts with policies. See :ref:`policies`.
         testing_demand_models (dict): Dict of dicts with demand models for tests. See
             :ref:`testing_demand_models` for more information.
         testing_allocation_models (dict): Dict of dicts with allocation models for
@@ -430,10 +430,36 @@ def _check_inputs(
     for name, pol in contact_policies.items():
         if not isinstance(pol, dict):
             raise ValueError(f"Each policy must be a dictionary: {name}.")
-        if name not in contact_models:
+        if "affected_contact_model" not in pol:
             raise KeyError(
-                f"contact_policy refers to non existent contact model: {name}."
+                f"contact_policy {name} must have a 'affected_contact_model' specified."
             )
+        model = pol["affected_contact_model"]
+        if model not in contact_models:
+            raise ValueError(f"Unknown affected_contact_model for {name}.")
+        if "policy" not in pol:
+            raise KeyError(f"contact_policy {name} must have a 'policy' specified.")
+
+        # the policy must either be a callable or a number between 0 and 1.
+        if not callable(pol["policy"]):
+            if not isinstance(pol["policy"], (float, int)):
+                raise ValueError(
+                    f"The 'policy' entry of {name} must be callable or a number."
+                )
+            elif (pol["policy"] > 1.0) or (pol["policy"] < 0.0):
+                raise ValueError(
+                    f"If 'policy' is a number it must lie between 0 and 1. "
+                    f"For {name} it is {pol['policy']}."
+                )
+            else:
+                recurrent = contact_models[model]["is_recurrent"]
+                assert not recurrent or pol["policy"] == 0.0, (
+                    f"Specifying multipliers for recurrent models such as {name} for "
+                    f"{pol['affected_contact_model']} will not change the contacts "
+                    "of anyone because for recurrent models it is only checked"
+                    "where the number of contacts is larger than 0. "
+                    "This is unaffected by any multiplier other than 0"
+                )
 
     for testing_model in [
         testing_demand_models,

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -417,11 +417,12 @@ def test_calculate_contacts_no_policy(states_all_alive, contact_models):
 
 def test_calculate_contacts_policy_inactive(states_all_alive, contact_models):
     contact_policies = {
-        "first_half_meet": {
+        "noone_meets": {
+            "affected_contact_model": "first_half_meet",
             "start": "2020-08-01",
             "end": "2020-08-30",
             "is_active": lambda x: True,
-            "multiplier": 0,
+            "policy": 0,
         },
     }
     date = pd.Timestamp("2020-09-29")
@@ -441,16 +442,73 @@ def test_calculate_contacts_policy_inactive(states_all_alive, contact_models):
 
 def test_calculate_contacts_policy_active(states_all_alive, contact_models):
     contact_policies = {
-        "first_half_meet": {
+        "noone_meets": {
+            "affected_contact_model": "first_half_meet",
             "start": "2020-09-01",
             "end": "2020-09-30",
             "is_active": lambda states: True,
-            "multiplier": 0,
+            "policy": 0,
         },
     }
     date = pd.Timestamp("2020-09-29")
     params = pd.DataFrame()
     expected = np.tile([1, 0], (len(states_all_alive), 1)).astype(DTYPE_N_CONTACTS)
+    res = calculate_contacts(
+        contact_models=contact_models,
+        contact_policies=contact_policies,
+        states=states_all_alive,
+        params=params,
+        date=date,
+    )
+    np.testing.assert_array_equal(expected, res)
+
+
+def test_calculate_contacts_policy_inactive_through_function(
+    states_all_alive, contact_models
+):
+    contact_policies = {
+        "noone_meets": {
+            "affected_contact_model": "first_half_meet",
+            "start": "2020-09-01",
+            "end": "2020-09-30",
+            "is_active": lambda states: False,
+            "policy": 0,
+        },
+    }
+    date = pd.Timestamp("2020-09-29")
+    params = pd.DataFrame()
+    expected = np.tile([1, 0], (len(states_all_alive), 1)).astype(DTYPE_N_CONTACTS)
+    first_half = round(len(states_all_alive) / 2)
+    expected[:first_half, 1] = 1
+    res = calculate_contacts(
+        contact_models=contact_models,
+        contact_policies=contact_policies,
+        states=states_all_alive,
+        params=params,
+        date=date,
+    )
+    np.testing.assert_array_equal(expected, res)
+
+
+def test_calculate_contacts_policy_active_policy_func(states_all_alive, contact_models):
+    def reduce_to_1st_quarter(states, contacts, params):
+        contacts = contacts.copy()
+        contacts[: int(len(contacts) / 4)] = 0
+        return contacts
+
+    contact_policies = {
+        "noone_meets": {
+            "affected_contact_model": "first_half_meet",
+            "start": "2020-09-01",
+            "end": "2020-09-30",
+            "policy": reduce_to_1st_quarter,
+            "is_active": lambda states: True,
+        },
+    }
+    date = pd.Timestamp("2020-09-29")
+    params = pd.DataFrame()
+    expected = np.tile([1, 0], (len(states_all_alive), 1)).astype(DTYPE_N_CONTACTS)
+    expected[2:4, 1] = 1
     res = calculate_contacts(
         contact_models=contact_models,
         contact_policies=contact_policies,


### PR DESCRIPTION
With these changes the user can:
- specify more than one policy per contact model.
- specify functions instead of just multipliers. This is especially important for recurrent contacts.

- [x] update documentation and add notebook showcasing the new behavior.
- [x] update checks on the contact_policies provided by the user.
- [x] implement the new behavior in `calculate_contacts`.
- [x] modify tests of `calculate_contacts` and add additional tests for the new functionality.

