### PR TITLE
Improve how initial infections are treated in sid.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: 3.8

--- a/docs/source/reference_guides/epi_params.rst
+++ b/docs/source/reference_guides/epi_params.rst
@@ -69,8 +69,9 @@ the preparation and ramp up of existing capacities in a country.
 .. rubric:: References
 
 - `Allocated tests and testing capacity in Germany
-  <https://de.wikipedia.org/wiki/COVID-19-Pandemie_in_Deutschland/Statistik>`_ on
-  Wikipedia, collected from daily RKI reports.
+  <https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/nCoV_node.html>`_ under
+  "Daten zum Download" and "Tabellen zu Testzahlen, Testkapazitäten und Probenrückstau
+  ...".
 
 
 Immunity Countdown

--- a/docs/source/reference_guides/states.rst
+++ b/docs/source/reference_guides/states.rst
@@ -8,13 +8,13 @@ The ``states`` DataFrame
 Introduction
 ------------
 
-The ``states`` DataFrame is the core of the covid simulator. It contains all
+The ``states`` DataFrame is the core of the COVID-19 simulator. It contains all
 characteristics of all individuals in the population. This includes all variables that
 influence the number of contacts, the dangerousness of the disease as well as the health
 status.
 
 All variables in ``states`` should be categorical with meaningful categories that can be
-directly used for plotting. Internally, we will work with the codes.
+directly used for plotting. Internally, we will work with the numeric codes.
 
 No NaNs are allowed in ``states``. If there are NaNs in the dataset with background
 characteristics, the user has to impute values or drop those observations.

--- a/src/sid/config.py
+++ b/src/sid/config.py
@@ -47,7 +47,7 @@ SAVED_COLUMNS = {
     "contacts": False,
     "countdown_draws": False,
     "group_codes": False,
-    "other": ["n_has_infected", "newly_infected"],
+    "other": ["n_has_infected", "newly_infected", "new_known_case"],
 }
 
 

--- a/src/sid/config.py
+++ b/src/sid/config.py
@@ -55,3 +55,10 @@ OPTIONAL_STATE_COLUMNS = {
     "contacts": False,
     "reason_for_infection": False,
 }
+
+
+INITIAL_CONDITIONS = {
+    "burn_in_periods": 14,
+    "assort_by": ["county"],
+    "growth_rate": 1.3,
+}

--- a/src/sid/config.py
+++ b/src/sid/config.py
@@ -17,6 +17,8 @@ BOOLEAN_STATE_COLUMNS = [
     "demands_test",
     "allocated_test",
     "to_be_processed_test",
+    "newly_deceased",
+    "new_known_case",
 ]
 
 DTYPE_COUNTDOWNS = np.int16

--- a/src/sid/covid_epi_params.csv
+++ b/src/sid/covid_epi_params.csv
@@ -19,7 +19,7 @@ cd_symptoms_false,all,22,0.3
 cd_symptoms_false,all,27,0.3
 cd_needs_icu_true,0-9,-1,0.99995
 cd_needs_icu_true,0-9,7,0.00005
-cd_needs_icu_true,10-19,-1,0.9997 
+cd_needs_icu_true,10-19,-1,0.9997
 cd_needs_icu_true,10-19,7,0.0003
 cd_needs_icu_true,20-29,-1,0.99925
 cd_needs_icu_true,20-29,7,0.00075
@@ -86,7 +86,11 @@ cd_dead_true,70-79,1,0.36
 cd_dead_true,70-79,12,0.20
 cd_dead_true,70-79,20,0.26
 cd_dead_true,70-79,32,0.06
-cd_dead_true,80-100,-1,1.00
+cd_dead_true,80-100,-1,0.12
+cd_dead_true,80-100,1,0.36
+cd_dead_true,80-100,12,0.20
+cd_dead_true,80-100,20,0.26
+cd_dead_true,80-100,32,0.06
 cd_needs_icu_false,all,1,0.22
 cd_needs_icu_false,all,15,0.30
 cd_needs_icu_false,all,25,0.30

--- a/src/sid/msm.py
+++ b/src/sid/msm.py
@@ -147,26 +147,11 @@ def _msm(
     root_contribs = np.sqrt(np.diagonal(weighting_matrix)) * moment_errors
     value = np.sum(root_contribs ** 2)
 
-    # goodness of fit information. Needs to be removed when cleaning up. Instead need
-    # a better way to specify that some moments should not be used for estimation but
-    # computed and saved for debugging.
-    all_infections_by_age = outcome_by_groups(
-        df=df, outcome="newly_infected", group="age_group_rki", scaling_factor=100_000
-    )
-
-    all_infections = outcome(
-        df=df,
-        outcome="newly_infected",
-        scaling_factor=100_000,
-    )
-
     out = {
         "value": value,
         "root_contributions": root_contribs,
         "empirical_moments": empirical_moments,
         "simulated_moments": simulated_moments,
-        "simulated_all_infections_age": all_infections_by_age,
-        "simulated_all_infections": all_infections,
     }
 
     return out

--- a/src/sid/msm.py
+++ b/src/sid/msm.py
@@ -125,6 +125,7 @@ def _msm(
     empirical_moments = copy.deepcopy(empirical_moments)
 
     df = simulate(params)
+    df = df.compute()
 
     simulated_moments = {name: func(df) for name, func in calc_moments.items()}
 
@@ -281,36 +282,20 @@ def _is_diagonal(mat):
 
 def cumulative_outcome(df, outcome, scaling_factor):
     return (
-        df.groupby(pd.Grouper(key="date", freq="W"))[outcome]
-        .mean()
-        .fillna(0)
-        .cumsum()
-        .compute()
+        df.groupby(pd.Grouper(key="date", freq="W"))[outcome].mean().fillna(0).cumsum()
         * scaling_factor
     )
 
 
 def outcome(df, outcome, scaling_factor):
     return (
-        df.groupby(pd.Grouper(key="date", freq="W"))[outcome].mean().fillna(0).compute()
+        df.groupby(pd.Grouper(key="date", freq="W"))[outcome].mean().fillna(0)
         * scaling_factor
     )
 
 
 def outcome_by_groups(df, outcome, group, scaling_factor):
-    if "age_group_rki" not in df.columns:
-        compute_age_groups(df)
     return (
-        df.groupby([pd.Grouper(key="date", freq="W"), group])[outcome]
-        .mean()
-        .fillna(0)
-        .compute()
+        df.groupby([pd.Grouper(key="date", freq="W"), group])[outcome].mean().fillna(0)
         * scaling_factor
     )
-
-
-def compute_age_groups(df):
-    intervals = pd.IntervalIndex.from_tuples(
-        [(0, 4), (5, 14), (15, 34), (35, 59), (60, 79), (80, 100)], closed="both"
-    )
-    df["age_group_rki"] = df["age"].map_partitions(pd.cut, intervals)

--- a/src/sid/msm.py
+++ b/src/sid/msm.py
@@ -278,24 +278,3 @@ def _flatten_index(data):
 
 def _is_diagonal(mat):
     return not np.count_nonzero(mat - np.diag(np.diagonal(mat)))
-
-
-def cumulative_outcome(df, outcome, scaling_factor):
-    return (
-        df.groupby(pd.Grouper(key="date", freq="W"))[outcome].mean().fillna(0).cumsum()
-        * scaling_factor
-    )
-
-
-def outcome(df, outcome, scaling_factor):
-    return (
-        df.groupby(pd.Grouper(key="date", freq="W"))[outcome].mean().fillna(0)
-        * scaling_factor
-    )
-
-
-def outcome_by_groups(df, outcome, group, scaling_factor):
-    return (
-        df.groupby([pd.Grouper(key="date", freq="W"), group])[outcome].mean().fillna(0)
-        * scaling_factor
-    )

--- a/src/sid/preparation.py
+++ b/src/sid/preparation.py
@@ -1,0 +1,179 @@
+import itertools as it
+
+import numba as nb
+import numpy as np
+import pandas as pd
+from sid.config import BOOLEAN_STATE_COLUMNS
+from sid.config import DTYPE_COUNTDOWNS
+from sid.config import DTYPE_INFECTION_COUNTER
+from sid.config import INITIAL_CONDITIONS
+from sid.contacts import boolean_choice
+from sid.countdowns import COUNTDOWNS
+from sid.pathogenesis import draw_course_of_disease
+from sid.shared import process_optional_state_columns
+from sid.update_states import update_states
+from sid.validation import validate_initial_states_and_infections
+from sid.validation import validate_params
+
+
+def prepare_initial_states(
+    initial_states,
+    initial_infections,
+    params,
+    initial_conditions=None,
+    optional_state_columns=None,
+    seed=None,
+):
+    """Prepare the initial states.
+
+    This functions prepares the initial states by drawing the course of the disease
+    for every individual and spreading the disease as defined by the initial
+    infections and initial conditions.
+
+    The function must be called on the user-defined states before they are passed to
+    the simulation and estimation routines. If the user received a states DataFrame
+    from the simulation or estimation, this step can be skipped.
+
+    Args:
+        initial_states (pandas.DataFrame): See :ref:`states`. Cannot contain the column
+            "date" because it is used internally.
+        initial_infections (pandas.Series): A series with the same index as
+            ``states`` which indicates individuals which are infected.
+        params (pandas.DataFrame): DataFrame with parameters that influence the number
+            of contacts, contagiousness and dangerousness of the disease, ... .
+        initial_conditions (dict): Dict containing the entries "burn_in_period" (int),
+            "assort_by" (list) and "growth_rate" (float). burn_in_periods and
+            growth_rate are
+            needed to spread out the initial infections over a period of time.
+            "assort_by" specifies the aggregation level on which
+            initial infections are scaled up to account for unknown cases.
+        optional_state_columns (dict): Dictionary with categories of state columns
+            that can additionally be added to the states dataframe, either for use in
+            contact models and policies or to be saved. Most types of columns are added
+            by default, but some of them are costly to add and thus only added when
+            needed. Columns that are not in the state but specified in ``saved_columns``
+            will not be saved. The categories are "contacts" and "reason_for_infection".
+        seed (int): The seed which controls the randomness in courses of diseases and
+            how infections progress.
+
+    Returns:
+        states (pandas.DataFrame): A DataFrame which can be used for simulating the
+            spread of the disease in the population.
+
+    """
+    initial_conditions = (
+        INITIAL_CONDITIONS
+        if initial_conditions is None
+        else {**INITIAL_CONDITIONS, **initial_conditions}
+    )
+
+    initial_states = initial_states.copy(deep=True)
+    initial_infections = initial_infections.copy(deep=True)
+    validate_initial_states_and_infections(initial_states, initial_infections)
+    validate_params(params)
+
+    optional_state_columns = process_optional_state_columns(optional_state_columns)
+
+    seed = it.count(np.random.randint(0, 1_000_000)) if seed is None else it.count(seed)
+
+    states = initialize_state_columns(initial_states)
+    states = draw_course_of_disease(states, params, seed)
+
+    scaled_infections = _scale_up_initial_infections(
+        initial_infections=initial_infections,
+        states=states,
+        params=params,
+        assort_by=initial_conditions["assort_by"],
+    )
+    spreading_infections = _spread_out_initial_infections(
+        scaled_infections=scaled_infections,
+        burn_in_periods=initial_conditions["burn_in_periods"],
+        growth_rate=initial_conditions["growth_rate"],
+    )
+
+    for infections in spreading_infections:
+        states = update_states(
+            states=states,
+            newly_infected_contacts=infections,
+            newly_infected_events=infections,
+            params=params,
+            seed=seed,
+            optional_state_columns=optional_state_columns,
+        )
+
+    return states
+
+
+def initialize_state_columns(states):
+    for col in BOOLEAN_STATE_COLUMNS:
+        if col not in states.columns:
+            states[col] = False
+
+    for col in COUNTDOWNS:
+        if col not in states.columns:
+            states[col] = -1
+        states[col] = states[col].astype(DTYPE_COUNTDOWNS)
+
+    states["n_has_infected"] = DTYPE_INFECTION_COUNTER(0)
+    states["pending_test_date"] = pd.NaT
+
+    return states
+
+
+def _scale_up_initial_infections(initial_infections, states, params, assort_by):
+    """Increase number of infections by a multiplier taken from params.
+
+    The relative number of cases between groups defined by the variables in
+    ``assort_by`` is preserved.
+
+    """
+    states["known_infections"] = initial_infections
+    average_infections = states.groupby(assort_by)["known_infections"].transform("mean")
+    states = states.drop(columns="known_infections")
+
+    multiplier = params.loc[("known_cases_multiplier",) * 3, "value"]
+    prob_numerator = average_infections * (multiplier - 1)
+    prob_denominator = 1 - average_infections
+    prob = prob_numerator / prob_denominator
+
+    scaled_up_arr = _scale_up_initial_infections_numba(
+        initial_infections.to_numpy(), prob.to_numpy()
+    )
+    scaled_up = pd.Series(scaled_up_arr, index=states.index)
+    return scaled_up
+
+
+def _spread_out_initial_infections(scaled_infections, burn_in_periods, growth_rate):
+    """Spread out initial infections over several periods, given a growth rate."""
+    scaled_infections = scaled_infections.to_numpy()
+    reversed_shares = []
+    end_of_period_share = 1
+    for _ in range(burn_in_periods):
+        start_of_period_share = end_of_period_share / growth_rate
+        added = end_of_period_share - start_of_period_share
+        reversed_shares.append(added)
+        end_of_period_share = start_of_period_share
+    shares = reversed_shares[::-1]
+    shares[-1] = 1 - np.sum([shares[:-1]])
+
+    hypothetical_infection_day = np.random.choice(
+        burn_in_periods, p=shares, replace=True, size=len(scaled_infections)
+    )
+
+    spread_infections = []
+    for period in range(burn_in_periods):
+        hypothetically_infected_on_that_day = hypothetical_infection_day == period
+        infected_at_all = scaled_infections
+        spread_infections.append(hypothetically_infected_on_that_day & infected_at_all)
+
+    return spread_infections
+
+
+@nb.jit
+def _scale_up_initial_infections_numba(initial_infections, probabilities):
+    n_obs = initial_infections.shape[0]
+    res = initial_infections.copy()
+    for i in range(n_obs):
+        if not res[i]:
+            res[i] = boolean_choice(probabilities[i])
+    return res

--- a/src/sid/shared.py
+++ b/src/sid/shared.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from sid.config import DTYPE_GROUP_CODE
 from sid.config import INDEX_NAMES
+from sid.config import OPTIONAL_STATE_COLUMNS
 from sid.config import ROOT_DIR
 
 
@@ -201,3 +202,12 @@ def date_is_within_start_and_end_date(date, start, end):
         is_within = False
 
     return is_within
+
+
+def process_optional_state_columns(opt_state_cols):
+    res = (
+        OPTIONAL_STATE_COLUMNS
+        if opt_state_cols is None
+        else {**OPTIONAL_STATE_COLUMNS, **opt_state_cols}
+    )
+    return res

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -295,7 +295,8 @@ def _simulate(
         newly_infected_events = calculate_infections_by_events(states, params, events)
 
         if testing_demand_models:
-            demands_test, demands_test_reason = calculate_demand_for_tests(
+            # demands_test, demands_test_reason = calculate_demand_for_tests(
+            demands_test = calculate_demand_for_tests(
                 states, testing_demand_models, params, date, seed
             )
             allocated_tests = allocate_tests(

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -781,7 +781,7 @@ def _scale_up_initial_infections(initial_infections, states, params, assort_by):
     """
     states = states.copy()
     index_tup = (
-        "initial_infections",
+        "known_cases_multiplier",
         "known_cases_multiplier",
         "known_cases_multiplier",
     )

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -5,17 +5,9 @@ import warnings
 from pathlib import Path
 
 import dask.dataframe as dd
-import numba as nb
 import numpy as np
-import pandas as pd
 from sid.config import BOOLEAN_STATE_COLUMNS
-from sid.config import DTYPE_COUNTDOWNS
-from sid.config import DTYPE_INFECTION_COUNTER
-from sid.config import INDEX_NAMES
-from sid.config import INITIAL_CONDITIONS
-from sid.config import OPTIONAL_STATE_COLUMNS
 from sid.config import SAVED_COLUMNS
-from sid.contacts import boolean_choice
 from sid.contacts import calculate_contacts
 from sid.contacts import calculate_infections_by_contacts
 from sid.contacts import create_group_indexer
@@ -23,19 +15,21 @@ from sid.countdowns import COUNTDOWNS
 from sid.events import calculate_infections_by_events
 from sid.matching_probabilities import create_group_transition_probs
 from sid.parse_model import parse_duration
-from sid.pathogenesis import draw_course_of_disease
 from sid.shared import factorize_assortative_variables
+from sid.shared import process_optional_state_columns
 from sid.testing_allocation import allocate_tests
 from sid.testing_allocation import update_pending_tests
 from sid.testing_demand import calculate_demand_for_tests
 from sid.testing_processing import process_tests
 from sid.update_states import update_states
+from sid.validation import validate_models
+from sid.validation import validate_params
+from sid.validation import validate_prepared_initial_states
 
 
 def get_simulate_func(
     params,
     initial_states,
-    initial_infections,
     contact_models,
     duration=None,
     events=None,
@@ -47,7 +41,6 @@ def get_simulate_func(
     path=None,
     saved_columns=None,
     optional_state_columns=None,
-    initial_conditions=None,
 ):
     """Get a function that simulates the spread of an infectious disease.
 
@@ -55,17 +48,12 @@ def get_simulate_func(
     to process the user input is only incurred once in :func:`get_simulate_func` and not
     when the resulting function is called.
 
-
     Args:
         params (pandas.DataFrame): DataFrame with parameters that influence the number
             of contacts, contagiousness and dangerousness of the disease, ... .
-        initial_states (pandas.DataFrame): See :ref:`states`. Cannot contain the column
-            "date" because it is used internally.
-        initial_infections (pandas.Series): Series with the same index as states with
-            initial infections. They are initial known cases. Sid will assume that
-            unknown cases have the same geographical structure. The number of
-            unknown cases is governed by the parameter ("initial_infections",
-            "known_cases_multiplier", "known_cases_multiplier").
+        initial_states (pandas.DataFrame): The output of
+            :func:`sid.spread_infections.spreat_out_infections` or from a
+            past simulation or estimation.
         contact_models (dict): Dictionary of dictionaries where each dictionary
             describes a channel by which contacts can be formed. See
             :ref:`contact_models`.
@@ -96,43 +84,26 @@ def get_simulate_func(
             by default, but some of them are costly to add and thus only added when
             needed. Columns that are not in the state but specified in ``saved_columns``
             will not be saved. The categories are "contacts" and "reason_for_infection".
-        initial_conditions (dict): Dict containing the entries "burn_in_period" (int),
-            "assort_by": list and "growth_rate". burn_in_periods and growth_rate are
-            needed to spread out the initial infections over a period of time.
-            "assort_by" specifies the aggregation level on which
-            we scale up the initial infections to account for unknown cases.
+
     Returns:
         callable: Simulates dataset based on parameters.
 
     """
     events = {} if events is None else events
     contact_policies = {} if contact_policies is None else contact_policies
-    testing_demand_models = (
-        {} if testing_demand_models is None else testing_demand_models
-    )
-    testing_allocation_models = (
-        {} if testing_allocation_models is None else testing_allocation_models
-    )
-    testing_processing_models = (
-        {} if testing_processing_models is None else testing_processing_models
-    )
-    initial_conditions = (
-        INITIAL_CONDITIONS
-        if initial_conditions is None
-        else {**INITIAL_CONDITIONS, **initial_conditions}
-    )
+    if testing_demand_models is None:
+        testing_demand_models = {}
+    if testing_allocation_models is None:
+        testing_allocation_models = {}
+    if testing_processing_models is None:
+        testing_processing_models = {}
 
-    optional_state_columns = _process_optional_state_columns(optional_state_columns)
-    user_state_columns = initial_states.columns
+    params = params.copy(deep=True)
     initial_states = initial_states.copy(deep=True)
-    params = _prepare_params(params)
 
-    path = _create_output_directory(path)
-
-    _check_inputs(
-        params,
-        initial_states,
-        initial_infections,
+    validate_params(params)
+    validate_prepared_initial_states(initial_states)
+    validate_models(
         contact_models,
         contact_policies,
         testing_demand_models,
@@ -151,15 +122,17 @@ def get_simulate_func(
 
     indexers = _prepare_assortative_matching_indexers(initial_states, assort_bys)
 
+    optional_state_columns = process_optional_state_columns(optional_state_columns)
     cols_to_keep = _process_saved_columns(
-        saved_columns, user_state_columns, contact_models, optional_state_columns
+        saved_columns, initial_states.columns, contact_models, optional_state_columns
     )
+
+    path = _create_output_directory(path)
 
     sim_func = functools.partial(
         _simulate,
         initial_states=initial_states,
         assort_bys=assort_bys,
-        initial_infections=initial_infections,
         contact_models=contact_models,
         duration=duration,
         events=events,
@@ -172,7 +145,6 @@ def get_simulate_func(
         columns_to_keep=cols_to_keep,
         indexers=indexers,
         optional_state_columns=optional_state_columns,
-        initial_conditions=initial_conditions,
     )
     return sim_func
 
@@ -181,7 +153,6 @@ def _simulate(
     params,
     initial_states,
     assort_bys,
-    initial_infections,
     contact_models,
     duration,
     events,
@@ -194,20 +165,15 @@ def _simulate(
     columns_to_keep,
     indexers,
     optional_state_columns,
-    initial_conditions,
 ):
     """Simulate the spread of an infectious disease.
 
     Args:
         params (pandas.DataFrame): DataFrame with parameters that influence the number
             of contacts, contagiousness and dangerousness of the disease, ... .
-        initial_states (pandas.DataFrame): See :ref:`states`. Cannot contain the column
-            "date" because it is used internally.
-        initial_infections (pandas.Series): Series with the same index as states with
-            initial infections. They are initial known cases. Sid will assume that
-            unknown cases have the same geographical structure. The number of
-            unknown cases is governed by the parameter ("initial_infections",
-            "known_cases_multiplier", "known_cases_multiplier").
+        initial_states (pandas.DataFrame): The output of
+            :func:`sid.preparation.prepare_initial_states` or states from a former
+            simulation or estimation.
         contact_models (dict): Dictionary of dictionaries where each dictionary
             describes a channel by which contacts can be formed. See
             :ref:`contact_models`.
@@ -231,11 +197,6 @@ def _simulate(
             by default, but some of them are costly to add and thus only added when
             needed. Columns that are not in the state but specified in ``saved_columns``
             will not be saved. The categories are "contacts" and "reason_for_infection".
-        initial_conditions (dict): Dict containing the entries "burn_in_period" (int),
-            "assort_by": list and "growth_rate". burn_in_periods and growth_rate are
-            needed to spread out the initial infections over a period of time.
-            "assort_by" specifies the aggregation level on which
-            we scale up the initial infections to account for unknown cases.
 
     Returns:
         simulation_results (dask.dataframe): The simulation results in form of a long
@@ -244,34 +205,11 @@ def _simulate(
 
     """
     seed = it.count(np.random.randint(0, 1_000_000)) if seed is None else it.count(seed)
+    states = initial_states
 
     cum_probs = _prepare_assortative_matching_probabilities(
-        initial_states, assort_bys, params, contact_models
+        states, assort_bys, params, contact_models
     )
-
-    states = draw_course_of_disease(initial_states, params, seed)
-
-    scaled_infections = _scale_up_initial_infections(
-        initial_infections=initial_infections,
-        states=states,
-        params=params,
-        assort_by=initial_conditions["assort_by"],
-    )
-    spread_out_infections = _spread_out_initial_infections(
-        scaled_infections=scaled_infections,
-        burn_in_periods=initial_conditions["burn_in_periods"],
-        growth_rate=initial_conditions["growth_rate"],
-    )
-
-    for infections in spread_out_infections:
-        states = update_states(
-            states=states,
-            newly_infected_contacts=infections,
-            newly_infected_events=infections,
-            params=params,
-            seed=seed,
-            optional_state_columns=optional_state_columns,
-        )
 
     for date in duration["dates"]:
         states["date"] = date
@@ -295,7 +233,6 @@ def _simulate(
         newly_infected_events = calculate_infections_by_events(states, params, events)
 
         if testing_demand_models:
-            # demands_test, demands_test_reason = calculate_demand_for_tests(
             demands_test = calculate_demand_for_tests(
                 states, testing_demand_models, params, date, seed
             )
@@ -309,8 +246,6 @@ def _simulate(
                 states, testing_processing_models, params, date
             )
         else:
-            demands_test = None
-            allocated_tests = None
             to_be_processed_tests = None
 
         states = update_states(
@@ -336,34 +271,6 @@ def _simulate(
     simulation_results = _return_dask_dataframe(path, categoricals)
 
     return simulation_results
-
-
-def _prepare_params(params):
-    """Check the supplied params and set the index if not done."""
-    if not isinstance(params, pd.DataFrame):
-        raise ValueError("params must be a DataFrame.")
-
-    params = params.copy()
-    if not (
-        isinstance(params.index, pd.MultiIndex) and params.index.names == INDEX_NAMES
-    ):
-        raise ValueError(
-            "params must have the index levels 'category', 'subcategory' and 'name'."
-        )
-
-    if np.any(params.index.to_frame().isna()):
-        raise ValueError(
-            "No NaNs allowed in the params index. Repeat the previous index level "
-            "instead."
-        )
-
-    if params.index.duplicated().any():
-        raise ValueError("No duplicates in the params index allowed.")
-
-    if params["value"].isna().any():
-        raise ValueError("The 'value' column of params must not contain NaNs.")
-
-    return params
 
 
 def _create_output_directory(path):
@@ -453,113 +360,6 @@ def _process_assort_bys(contact_models):
     return assort_bys
 
 
-def _check_inputs(
-    params,
-    initial_states,
-    initial_infections,
-    contact_models,
-    contact_policies,
-    testing_demand_models,
-    testing_allocation_models,
-    testing_processing_models,
-):
-    """Check the user inputs."""
-    cd_names = sorted(COUNTDOWNS)
-    gb = params.loc[cd_names].groupby(INDEX_NAMES[:2])
-    prob_sums = gb["value"].sum()
-    problematic = prob_sums[~prob_sums.between(1 - 1e-08, 1 + 1e-08)].index.tolist()
-    assert (
-        len(problematic) == 0
-    ), f"The following countdown probabilities don't add up to 1: {problematic}"
-
-    if not isinstance(initial_states, pd.DataFrame):
-        raise ValueError("initial_states must be a DataFrame.")
-
-    if not isinstance(initial_infections, pd.Series):
-        raise ValueError("initial_infections must be a pandas Series.")
-
-    if not initial_infections.index.equals(initial_states.index):
-        raise ValueError("initial_states and initial_infections must have same index.")
-
-    if not isinstance(contact_models, dict):
-        raise ValueError("contact_models must be a dictionary.")
-
-    for cm_name, cm in contact_models.items():
-        if not isinstance(cm, dict):
-            raise ValueError(f"Each contact model must be a dictionary: {cm_name}.")
-
-    if not isinstance(contact_policies, dict):
-        raise ValueError("policies must be a dictionary.")
-
-    for name, pol in contact_policies.items():
-        if not isinstance(pol, dict):
-            raise ValueError(f"Each policy must be a dictionary: {name}.")
-        if "affected_contact_model" not in pol:
-            raise KeyError(
-                f"contact_policy {name} must have a 'affected_contact_model' specified."
-            )
-        model = pol["affected_contact_model"]
-        if model not in contact_models:
-            raise ValueError(f"Unknown affected_contact_model for {name}.")
-        if "policy" not in pol:
-            raise KeyError(f"contact_policy {name} must have a 'policy' specified.")
-
-        # the policy must either be a callable or a number between 0 and 1.
-        if not callable(pol["policy"]):
-            if not isinstance(pol["policy"], (float, int)):
-                raise ValueError(
-                    f"The 'policy' entry of {name} must be callable or a number."
-                )
-            elif (pol["policy"] > 1.0) or (pol["policy"] < 0.0):
-                raise ValueError(
-                    f"If 'policy' is a number it must lie between 0 and 1. "
-                    f"For {name} it is {pol['policy']}."
-                )
-            else:
-                recurrent = contact_models[model]["is_recurrent"]
-                assert not recurrent or pol["policy"] == 0.0, (
-                    f"Specifying multipliers for recurrent models such as {name} for "
-                    f"{pol['affected_contact_model']} will not change the contacts "
-                    "of anyone because for recurrent models it is only checked"
-                    "where the number of contacts is larger than 0. "
-                    "This is unaffected by any multiplier other than 0"
-                )
-
-    for testing_model in [
-        testing_demand_models,
-        testing_allocation_models,
-        testing_processing_models,
-    ]:
-        for name in testing_model:
-            if not isinstance(testing_model[name], dict):
-                raise ValueError(f"Each testing model must be a dictionary: {name}.")
-
-            if "model" not in testing_model[name]:
-                raise ValueError(
-                    f"Each testing model must have a 'model' entry: {name}."
-                )
-
-    first_levels = params.index.get_level_values("category")
-    assort_prob_matrices = [
-        x for x in first_levels if x.startswith("assortative_matching_")
-    ]
-    for name in assort_prob_matrices:
-        meeting_prob = params.loc[name]["value"].unstack()
-        assert len(meeting_prob.index) == len(
-            meeting_prob.columns
-        ), f"assortative probability matrices must be square but isn't for {name}."
-        assert (
-            meeting_prob.index == meeting_prob.columns
-        ).all(), (
-            f"assortative probability matrices must be square but isn't for {name}."
-        )
-        assert (meeting_prob.sum(axis=1) > 0.9999).all() & (
-            meeting_prob.sum(axis=1) < 1.00001
-        ).all(), (
-            f"the meeting probabilities of {name} do not add up to one in every row."
-        )
-
-
 def _prepare_assortative_matching_indexers(states, assort_bys):
     """Create indexers and first stage probabilities for assortative matching.
 
@@ -632,9 +432,6 @@ def _process_initial_states(states, assort_bys):
         states (pandas.DataFrame): Processed states.
 
     """
-    if np.any(states.isna()):
-        raise ValueError("'initial_states' are not allowed to contain NaNs.")
-
     # Check if all assort_by columns are categoricals. This is important to save memory.
     assort_by_variables = list(
         set(it.chain.from_iterable(a_b for a_b in assort_bys.values()))
@@ -647,18 +444,6 @@ def _process_initial_states(states, assort_bys):
     # be dropped while writing to parquet. Parquet stores an efficient range index
     # instead.
     states = states.sort_index().reset_index()
-
-    for col in BOOLEAN_STATE_COLUMNS:
-        if col not in states.columns:
-            states[col] = False
-
-    for col in COUNTDOWNS:
-        if col not in states.columns:
-            states[col] = -1
-        states[col] = states[col].astype(DTYPE_COUNTDOWNS)
-
-    states["n_has_infected"] = DTYPE_INFECTION_COUNTER(0)
-    states["pending_test_date"] = pd.NaT
 
     for model_name, assort_by in assort_bys.items():
         states[f"group_codes_{model_name}"], _ = factorize_assortative_variables(
@@ -734,78 +519,4 @@ def _combine_column_lists(user_entries, all_entries):
     else:
         res = []
     res = list(res)
-    return res
-
-
-def _process_optional_state_columns(opt_state_cols):
-    res = (
-        OPTIONAL_STATE_COLUMNS
-        if opt_state_cols is None
-        else {**OPTIONAL_STATE_COLUMNS, **opt_state_cols}
-    )
-    return res
-
-
-def _spread_out_initial_infections(scaled_infections, burn_in_periods, growth_rate):
-    """Spread out initial infections over several periods, given a growth rate."""
-    scaled_infections = scaled_infections.to_numpy()
-    reversed_shares = []
-    end_of_period_share = 1
-    for _ in range(burn_in_periods):
-        start_of_period_share = end_of_period_share / growth_rate
-        added = end_of_period_share - start_of_period_share
-        reversed_shares.append(added)
-        end_of_period_share = start_of_period_share
-    shares = reversed_shares[::-1]
-    shares[-1] = 1 - np.sum([shares[:-1]])
-
-    hypothetical_infection_day = np.random.choice(
-        burn_in_periods, p=shares, replace=True, size=len(scaled_infections)
-    )
-
-    spread_infections = []
-    for period in range(burn_in_periods):
-        hypothetially_infected_on_that_day = hypothetical_infection_day == period
-        infected_at_all = scaled_infections
-        spread_infections.append(hypothetially_infected_on_that_day & infected_at_all)
-
-    return spread_infections
-
-
-def _scale_up_initial_infections(initial_infections, states, params, assort_by):
-    """Increase number of infections by a multiplier taken from params.
-
-    The relative number of cases between groups defined by the variables in
-    ``assort_by`` is preserved.
-
-    """
-    states = states.copy()
-    index_tup = (
-        "known_cases_multiplier",
-        "known_cases_multiplier",
-        "known_cases_multiplier",
-    )
-    multiplier = params.loc[index_tup, "value"]
-    states["known_infections"] = initial_infections
-    average_infections = states.groupby(assort_by)["known_infections"].transform(
-        np.mean
-    )
-    prob_numerator = average_infections * (multiplier - 1)
-    prob_denominator = 1 - average_infections
-    prob = prob_numerator / prob_denominator
-
-    scaled_up_arr = _scale_up_initial_infections_numba(
-        initial_infections.to_numpy(), prob.to_numpy()
-    )
-    scaled_up = pd.Series(scaled_up_arr, index=states.index)
-    return scaled_up
-
-
-@nb.jit
-def _scale_up_initial_infections_numba(initial_infections, probabilities):
-    n_obs = initial_infections.shape[0]
-    res = initial_infections.copy()
-    for i in range(n_obs):
-        if not res[i]:
-            res[i] = boolean_choice(probabilities[i])
     return res

--- a/src/sid/testing_demand.py
+++ b/src/sid/testing_demand.py
@@ -42,11 +42,8 @@ def calculate_demand_for_tests(states, testing_demand_models, params, date, seed
     )
 
     demands_test = _sample_which_individuals_demand_a_test(demand_probabilities, seed)
-    demands_test_reason = _sample_reason_for_demanding_a_test(
-        demand_probabilities, demands_test, seed
-    )
 
-    return demands_test, demands_test_reason
+    return demands_test
 
 
 def _calculate_demand_probabilities(states, testing_demand_models, params, date):

--- a/src/sid/update_states.py
+++ b/src/sid/update_states.py
@@ -85,6 +85,9 @@ def update_states(
 
     states = _kill_people_over_icu_limit(states, params, seed)
 
+    # important: this has to be called after _kill_people_over_icu_limit!
+    states["newly_deceased"] = states["cd_dead_true"] == 0
+
     # Add additional information.
     if optional_state_columns["contacts"]:
         if isinstance(optional_state_columns, list):

--- a/src/sid/update_states.py
+++ b/src/sid/update_states.py
@@ -124,6 +124,10 @@ def update_states(
         ]
         states.loc[knows_infectious, "knows_infectious"] = True
 
+        states["new_known_case"] = (
+            states["cd_received_test_result_true"] == 0
+        ) & states["immune"]
+
         # Everyone looses ``received_test_result == True`` because it is passed to the
         # more specific knows attributes.
         states.loc[states.received_test_result, "received_test_result"] = False

--- a/src/sid/validation.py
+++ b/src/sid/validation.py
@@ -1,0 +1,147 @@
+"""This module contains routines to validate inputs to functions."""
+import numpy as np
+import pandas as pd
+from sid.config import BOOLEAN_STATE_COLUMNS
+from sid.config import INDEX_NAMES
+from sid.countdowns import COUNTDOWNS
+
+
+def validate_params(params):
+    """Validate the parameter DataFrame."""
+    if not isinstance(params, pd.DataFrame):
+        raise ValueError("params must be a DataFrame.")
+
+    params = params.copy()
+    if not (
+        isinstance(params.index, pd.MultiIndex) and params.index.names == INDEX_NAMES
+    ):
+        raise ValueError(
+            "params must have the index levels 'category', 'subcategory' and 'name'."
+        )
+
+    if np.any(params.index.to_frame().isna()):
+        raise ValueError(
+            "No NaNs allowed in the params index. Repeat the previous index level "
+            "instead."
+        )
+
+    if params.index.duplicated().any():
+        raise ValueError("No duplicates in the params index allowed.")
+
+    if params["value"].isna().any():
+        raise ValueError("The 'value' column of params must not contain NaNs.")
+
+    cd_names = sorted(COUNTDOWNS)
+    gb = params.loc[cd_names].groupby(INDEX_NAMES[:2])
+    prob_sums = gb["value"].sum()
+    problematic = prob_sums[~prob_sums.between(1 - 1e-08, 1 + 1e-08)].index.tolist()
+    assert (
+        len(problematic) == 0
+    ), f"The following countdown probabilities don't add up to 1: {problematic}"
+
+    first_levels = params.index.get_level_values("category")
+    assort_prob_matrices = [
+        x for x in first_levels if x.startswith("assortative_matching_")
+    ]
+    for name in assort_prob_matrices:
+        meeting_prob = params.loc[name]["value"].unstack()
+        assert len(meeting_prob.index) == len(
+            meeting_prob.columns
+        ), f"assortative probability matrices must be square but isn't for {name}."
+        assert (
+            meeting_prob.index == meeting_prob.columns
+        ).all(), (
+            f"assortative probability matrices must be square but isn't for {name}."
+        )
+        assert (meeting_prob.sum(axis=1) > 0.9999).all() & (
+            meeting_prob.sum(axis=1) < 1.00001
+        ).all(), (
+            f"the meeting probabilities of {name} do not add up to one in every row."
+        )
+
+
+def validate_initial_states_and_infections(initial_states, initial_infections):
+    if not isinstance(initial_states, pd.DataFrame):
+        raise ValueError("initial_states must be a DataFrame.")
+
+    if not isinstance(initial_infections, pd.Series):
+        raise ValueError("initial_infections must be a pandas Series.")
+
+    if not initial_infections.index.equals(initial_states.index):
+        raise ValueError("initial_states and initial_infections must have same index.")
+
+
+def validate_prepared_initial_states(states):
+    if np.any(states.drop(columns="pending_test_date", errors="ignore").isna()):
+        raise ValueError("'initial_states' are not allowed to contain NaNs.")
+
+    for column in BOOLEAN_STATE_COLUMNS:
+        if states[column].dtype != "bool":
+            raise ValueError(f"Column '{column}' must be a boolean.")
+
+
+def validate_models(
+    contact_models,
+    contact_policies,
+    testing_demand_models,
+    testing_allocation_models,
+    testing_processing_models,
+):
+    """Check the user inputs."""
+    if not isinstance(contact_models, dict):
+        raise ValueError("contact_models must be a dictionary.")
+
+    for cm_name, cm in contact_models.items():
+        if not isinstance(cm, dict):
+            raise ValueError(f"Each contact model must be a dictionary: {cm_name}.")
+
+    if not isinstance(contact_policies, dict):
+        raise ValueError("policies must be a dictionary.")
+
+    for name, pol in contact_policies.items():
+        if not isinstance(pol, dict):
+            raise ValueError(f"Each policy must be a dictionary: {name}.")
+        if "affected_contact_model" not in pol:
+            raise KeyError(
+                f"contact_policy {name} must have a 'affected_contact_model' specified."
+            )
+        model = pol["affected_contact_model"]
+        if model not in contact_models:
+            raise ValueError(f"Unknown affected_contact_model for {name}.")
+        if "policy" not in pol:
+            raise KeyError(f"contact_policy {name} must have a 'policy' specified.")
+
+        # the policy must either be a callable or a number between 0 and 1.
+        if not callable(pol["policy"]):
+            if not isinstance(pol["policy"], (float, int)):
+                raise ValueError(
+                    f"The 'policy' entry of {name} must be callable or a number."
+                )
+            elif (pol["policy"] > 1.0) or (pol["policy"] < 0.0):
+                raise ValueError(
+                    f"If 'policy' is a number it must lie between 0 and 1. "
+                    f"For {name} it is {pol['policy']}."
+                )
+            else:
+                recurrent = contact_models[model]["is_recurrent"]
+                assert not recurrent or pol["policy"] == 0.0, (
+                    f"Specifying multipliers for recurrent models such as {name} for "
+                    f"{pol['affected_contact_model']} will not change the contacts "
+                    "of anyone because for recurrent models it is only checked"
+                    "where the number of contacts is larger than 0. "
+                    "This is unaffected by any multiplier other than 0"
+                )
+
+    for testing_model in [
+        testing_demand_models,
+        testing_allocation_models,
+        testing_processing_models,
+    ]:
+        for name in testing_model:
+            if not isinstance(testing_model[name], dict):
+                raise ValueError(f"Each testing model must be a dictionary: {name}.")
+
+            if "model" not in testing_model[name]:
+                raise ValueError(
+                    f"Each testing model must have a 'model' entry: {name}."
+                )

--- a/tests/test_params.csv
+++ b/tests/test_params.csv
@@ -15,3 +15,4 @@ cd_received_test_result_true,all,2,1
 cd_knows_immune_false,all,-1,1
 cd_knows_infectious_false,all,-1,1
 cd_ever_infected,all,-1,1
+initial_infections,known_cases_multiplier,known_cases_multiplier,1.1

--- a/tests/test_params.csv
+++ b/tests/test_params.csv
@@ -11,8 +11,8 @@ cd_dead_true,all,2,1,,
 cd_needs_icu_false,all,20,1,,
 health_system,icu_limit_relative,icu_limit_relative,0.0005,,
 infection_prob,standard,standard,0.05,,
-cd_received_test_result_true,all,2,1
-cd_knows_immune_false,all,-1,1
-cd_knows_infectious_false,all,-1,1
-cd_ever_infected,all,-1,1
-initial_infections,known_cases_multiplier,known_cases_multiplier,1.1
+cd_received_test_result_true,all,2,1,,
+cd_knows_immune_false,all,-1,1,,
+cd_knows_infectious_false,all,-1,1,,
+cd_ever_infected,all,-1,1,,
+known_cases_multiplier,known_cases_multiplier,known_cases_multiplier,1.1,,

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -3,7 +3,8 @@ import pandas as pd
 import pytest
 from pandas.api.types import is_categorical_dtype
 from sid.config import INDEX_NAMES
-from sid.simulate import _prepare_params
+from sid.preparation import prepare_initial_states
+from sid.preparation import validate_params
 from sid.simulate import _process_assort_bys
 from sid.simulate import _process_initial_states
 from sid.simulate import get_simulate_func
@@ -26,10 +27,11 @@ def test_simple_run(params, initial_states, tmp_path):
     initial_infections = pd.Series(index=initial_states.index, data=False)
     initial_infections.iloc[0] = True
 
+    states = prepare_initial_states(initial_states, initial_infections, params)
+
     simulate = get_simulate_func(
         params,
-        initial_states,
-        initial_infections,
+        states,
         CONTACT_MODELS,
         path=tmp_path,
     )
@@ -59,14 +61,14 @@ def test_prepare_params(params):
     params = params.copy().append(s)
 
     with pytest.raises(ValueError, match="No NaNs allowed in the params index."):
-        _prepare_params(params)
+        validate_params(params)
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("input_", [pd.Series(dtype="object"), (), 1, [], {}, set()])
 def test_prepare_params_with_wrong_inputs(input_):
     with pytest.raises(ValueError, match="params must be a DataFrame."):
-        _prepare_params(input_)
+        validate_params(input_)
 
 
 @pytest.mark.unit
@@ -74,7 +76,7 @@ def test_prepare_params_not_three_dimensional_multi_index(params):
     params = params.copy().reset_index(drop=True)
 
     with pytest.raises(ValueError, match="params must have the index levels"):
-        _prepare_params(params)
+        validate_params(params)
 
 
 @pytest.mark.unit
@@ -82,7 +84,7 @@ def test_prepare_params_no_duplicates_in_index(params):
     params = params.copy().append(params)
 
     with pytest.raises(ValueError, match="No duplicates in the params index allowed."):
-        _prepare_params(params)
+        validate_params(params)
 
 
 @pytest.mark.unit
@@ -91,4 +93,4 @@ def test_prepare_params_value_with_nan(params):
     params["value"].iloc[0] = np.nan
 
     with pytest.raises(ValueError, match="The 'value' column of params must not"):
-        _prepare_params(params)
+        validate_params(params)

--- a/tests/test_states.csv
+++ b/tests/test_states.csv
@@ -1,16 +1,16 @@
-age_group,region
-Under 50,a
-Under 50,b
-Under 50,c
-Under 50,a
-Under 50,b
-Under 50,c
-Under 50,a
-Over 50,b
-Over 50,c
-Over 50,a
-Over 50,b
-Over 50,c
-Over 50,a
-Over 50,b
-Over 50,c
+age_group,region,county
+Under 50,a,0
+Under 50,b,2
+Under 50,c,4
+Under 50,a,0
+Under 50,b,2
+Under 50,c,4
+Under 50,a,1
+Over 50,b,3
+Over 50,c,5
+Over 50,a,1
+Over 50,b,3
+Over 50,c,5
+Over 50,a,1
+Over 50,b,3
+Over 50,c,5

--- a/tests/test_testing_demand.py
+++ b/tests/test_testing_demand.py
@@ -13,13 +13,8 @@ def test_calculate_demand_for_tests(initial_states, params, ask_for_tests):
     }
     seed = itertools.count(0)
 
-    demands_test, demands_test_reason = calculate_demand_for_tests(
+    demands_test = calculate_demand_for_tests(
         initial_states, testing_demand_models, params, "2020-01-01", seed
     )
 
     assert (demands_test == ask_for_tests).all()
-    assert (
-        demands_test_reason.eq("dummy_model").all()
-        if ask_for_tests
-        else demands_test_reason.isna().all()
-    )


### PR DESCRIPTION
### Current behavior

When handling initial infections we ignore that there are unreported cases. The idea was, that one starts with only a hand full of initial infections in January, simulates until March and only then starts to match observed case numbers. However, it would require a sophisticated mix of initial infections and imported cases to arrive at a reasonable geographical distribution in march. 

### Desired behavior

To reduce computational time and complexity and to get a better geographical distribution of cases from the start we now suggest to pass in case numbers from a time where the pandemic already started. 

### Implementation

- initial infections are scaled up by a multiplier to account for unobserved cases
- initial infections are spread out over a period of time (default 2 weeks) over which we assume exponential growth of case numbers
- `update_states` is called with those case numbers in each burn_in period in order to get a warm started model (where people are in all stages of the disease) when we start the actual simulation.
