### PR TITLE
Skip missing group

### DIFF
--- a/src/sid/matching_probabilities.py
+++ b/src/sid/matching_probabilities.py
@@ -21,7 +21,9 @@ def create_group_transition_probs(states, assort_by, params, model_name):
             j or lower.
 
     """
-    _, group_codes_values = factorize_assortative_variables(states, assort_by)
+    _, group_codes_values = factorize_assortative_variables(
+        states, assort_by, is_recurrent=False
+    )
 
     if not assort_by:
         probs = np.ones((len(group_codes_values), len(group_codes_values)))

--- a/src/sid/shared.py
+++ b/src/sid/shared.py
@@ -23,7 +23,7 @@ def get_date(states):
     return out
 
 
-def factorize_assortative_variables(states, assort_by):
+def factorize_assortative_variables(states, assort_by, is_recurrent):
     """Factorize assortative variables.
 
     This function forms unique values by combining the different values of assortative
@@ -36,6 +36,7 @@ def factorize_assortative_variables(states, assort_by):
         states (pandas.DataFrame): The user-defined initial states.
         assort_by (list, optional): List of variable names. Contacts are assortative by
             these variables.
+        is_recurrent (bool)
 
     Returns:
         (tuple): Tuple containing
@@ -45,13 +46,17 @@ def factorize_assortative_variables(states, assort_by):
           correspond the values of assortative variables to form the group.
 
     """
-    if assort_by:
+    if is_recurrent:
+        assert isinstance(assort_by, list)
+        assert len(assort_by) == 1
+        assort_by_series = states[assort_by[0]].replace({-1: pd.NA})
+        group_codes, group_codes_values = pd.factorize(assort_by_series)
+    elif assort_by:
         assort_by_series = [states[col].to_numpy() for col in assort_by]
         group_codes, group_codes_values = pd.factorize(
             pd._libs.lib.fast_zip(assort_by_series), sort=True
         )
         group_codes = group_codes.astype(DTYPE_GROUP_CODE)
-
     else:
         group_codes = np.zeros(len(states), dtype=np.uint8)
         group_codes_values = [(0,)]

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -197,7 +197,9 @@ def get_simulate_func(
         validate_prepared_initial_states(initial_states, duration)
     else:
         validate_initial_states(initial_states)
-        initial_states = _process_initial_states(initial_states, assort_bys)
+        initial_states = _process_initial_states(
+            initial_states, assort_bys, contact_models
+        )
         initial_states = draw_course_of_disease(
             initial_states, params, next(startup_seed)
         )
@@ -205,7 +207,9 @@ def get_simulate_func(
             initial_states, params, initial_conditions, startup_seed
         )
 
-    indexers = _prepare_assortative_matching_indexers(initial_states, assort_bys)
+    indexers = _prepare_assortative_matching_indexers(
+        initial_states, assort_bys, contact_models
+    )
 
     cols_to_keep = _process_saved_columns(
         saved_columns, user_state_columns, contact_models, optional_state_columns
@@ -514,7 +518,7 @@ def _process_assort_bys(contact_models: Dict[str, Any]) -> Dict[str, List[str]]:
 
 
 def _prepare_assortative_matching_indexers(
-    states: pd.DataFrame, assort_bys: Dict[str, List[str]]
+    states: pd.DataFrame, assort_bys: Dict[str, List[str]], contact_models
 ) -> Dict[str, nb.typed.List]:
     """Create indexers and first stage probabilities for assortative matching.
 
@@ -530,7 +534,10 @@ def _prepare_assortative_matching_indexers(
     """
     indexers = {}
     for model_name, assort_by in assort_bys.items():
-        indexers[model_name] = create_group_indexer(states, assort_by)
+        is_recurrent = contact_models[model_name]["is_recurrent"]
+        indexers[model_name] = create_group_indexer(
+            states, assort_by, is_recurrent=is_recurrent
+        )
 
     return indexers
 
@@ -575,7 +582,7 @@ def _add_defaults_to_policy_dict(pol_dict, duration):
     return default
 
 
-def _process_initial_states(states, assort_bys):
+def _process_initial_states(states, assort_bys, contact_models):
     """Process the initial states given by the user.
 
     Args:
@@ -616,8 +623,11 @@ def _process_initial_states(states, assort_bys):
     states["pending_test_date"] = pd.NaT
 
     for model_name, assort_by in assort_bys.items():
+        is_recurrent = contact_models[model_name]["is_recurrent"]
         states[f"group_codes_{model_name}"], _ = factorize_assortative_variables(
-            states, assort_by
+            states,
+            assort_by,
+            is_recurrent=is_recurrent,
         )
 
     return states

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -31,6 +31,14 @@ def test_create_group_indexer(initial_states, assort_by, expected):
     assert calculated == expected
 
 
+def test_create_group_indexer_recurrent():
+    df = pd.DataFrame()
+    df["some_id"] = pd.Series([1, -1, 2, 2, 1]).astype("category")
+    calculated = create_group_indexer(df, ["some_id"], True)
+    calculated = [arr.tolist() for arr in calculated]
+    assert calculated == [[0, 4], [2, 3]]
+
+
 @pytest.mark.parametrize("seed", range(10))
 def test_calculate_infections_numba_with_single_group(num_regression, seed):
     """If you need to regenerate the test data, use ``pytest --force-regen``."""

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -25,7 +25,7 @@ from sid.contacts import create_group_indexer
     ],
 )
 def test_create_group_indexer(initial_states, assort_by, expected):
-    calculated = create_group_indexer(initial_states, assort_by)
+    calculated = create_group_indexer(initial_states, assort_by, is_recurrent=False)
     calculated = [arr.tolist() for arr in calculated]
 
     assert calculated == expected
@@ -173,7 +173,9 @@ def setup_households_w_one_infection():
         ),
     )
 
-    indexers = {"households": create_group_indexer(states, ["households"])}
+    indexers = {
+        "households": create_group_indexer(states, ["households"], is_recurrent=False)
+    }
 
     group_probs = {}
 
@@ -341,7 +343,11 @@ def test_calculate_infections_only_non_recurrent(
         data=1.0,
         index=pd.MultiIndex.from_tuples([("infection_prob", "non_rec", "non_rec")]),
     )
-    indexers = {"non_rec": create_group_indexer(states, ["group_codes_non_rec"])}
+    indexers = {
+        "non_rec": create_group_indexer(
+            states, ["group_codes_non_rec"], is_recurrent=False
+        )
+    }
     group_probs = {"non_rec": np.array([[0.8, 1], [0.2, 1]])}
 
     with monkeypatch.context() as m:

--- a/tests/test_initial_conditions.py
+++ b/tests/test_initial_conditions.py
@@ -220,7 +220,9 @@ def test_scale_and_spread_initial_infections(
     initial_states, params, initial_conditions, seed, expectation, expected
 ):
     with expectation:
-        initial_states = _process_initial_states(initial_states, {"a": []})
+        initial_states = _process_initial_states(
+            initial_states, {"a": []}, {"a": {"is_recurrent": False}}
+        )
         initial_states = draw_course_of_disease(initial_states, params, 0)
 
         result = sample_initial_distribution_of_infections_and_immunity(

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -23,7 +23,9 @@ from sid.shared import factorize_assortative_variables
     ],
 )
 def test_factorize_assortative_variables(initial_states, assort_by, expected):
-    _, group_code_values = factorize_assortative_variables(initial_states, assort_by)
+    _, group_code_values = factorize_assortative_variables(
+        initial_states, assort_by, False
+    )
 
     assert set(group_code_values) == set(expected)
 

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -36,10 +36,10 @@ def test_simulate_a_simple_model(params, initial_states, tmp_path):
 def test_check_assort_by_are_categoricals(initial_states):
     assort_bys = _process_assort_bys(CONTACT_MODELS)
 
-    _ = _process_initial_states(initial_states, assort_bys)
+    _ = _process_initial_states(initial_states, assort_bys, CONTACT_MODELS)
 
     initial_states = initial_states.astype(str)
-    processed = _process_initial_states(initial_states, assort_bys)
+    processed = _process_initial_states(initial_states, assort_bys, CONTACT_MODELS)
     for var in ["age_group", "region"]:
         assert is_categorical_dtype(processed[var].dtype)
 


### PR DESCRIPTION
### Current behavior

We do not handle non attendants in recurrent contact models in sid, but in each contact model. This is slow and error prone. 

### Desired behavior

-1 in an assort_by column for a recurrent contact model signals that that person never participates in the contact model. 