### PR TITLE
Improve dtype handling for random contacts.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -23,6 +23,9 @@ all releases are available on `Anaconda.org
 - :gh:`102` separates the calculation of contacts from applying policies.
 - :gh:`104` implements a seasonality factor which scales infection probabilities.
 - :gh:`106` allows policies to affect all contacts and not a single contact model.
+- :gh:`107` allows compute derived state variables which can be used across model
+  features to save some computations.
+- :gh:`108` enhances dtype conversion of random contact models.
 
 
 0.0.3 - 2021-03-23

--- a/src/sid/contacts.py
+++ b/src/sid/contacts.py
@@ -623,13 +623,17 @@ def post_process_contacts(contacts, states, contact_models):
     if random_models:
         random_contacts = contacts[random_models]
 
-        integers = random_contacts.select_dtypes(include=np.integer).columns
-        random_contacts[integers] = random_contacts[integers].astype(DTYPE_N_CONTACTS)
+        integers = random_contacts.select_dtypes(include=np.integer).columns.tolist()
+        if integers:
+            random_contacts[integers] = random_contacts[integers].astype(
+                DTYPE_N_CONTACTS
+            )
 
-        floats = random_contacts.select_dtypes(include=np.floating).columns
-        random_contacts[floats] = random_contacts[floats].apply(
-            lambda x: _sum_preserving_round(x.to_numpy()).astype(DTYPE_N_CONTACTS)
-        )
+        floats = random_contacts.select_dtypes(include=np.floating).columns.tolist()
+        if floats:
+            random_contacts[floats] = random_contacts[floats].apply(
+                lambda x: _sum_preserving_round(x.to_numpy()).astype(DTYPE_N_CONTACTS)
+            )
 
         no_integers = random_contacts.select_dtypes(exclude=np.integer).columns.tolist()
         if no_integers:

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ filterwarnings =
     ignore: indexing past lexsort depth may impact performance.
     ignore: numpy.ufunc size changed, may indicate binary incompatibility.
     ignore: `np\..*` is a deprecated alias for
+    ignore: SelectableGroups dict interface is deprecated
 junit_family = xunit2
 markers =
     unit: Unit tests.


### PR DESCRIPTION
Only check dtype in the `post_process_contacts`. Only apply `_sum_preserving_round` on `float` columns.

Before-After picture:

![image](https://user-images.githubusercontent.com/9567321/115041991-5c5fc380-9ed3-11eb-855d-fafd1cb54b49.png)
