### PR TITLE
Make it possible to have different seasonalities for different contact types

### DIFF
--- a/src/sid/contacts.py
+++ b/src/sid/contacts.py
@@ -104,8 +104,8 @@ def calculate_infections_by_contacts(
         virus_strains (Dict[str, Any]): A dictionary with the keys ``"names"`` and
             ``"factors"`` holding the different contagiousness factors of multiple
             viruses.
-        seasonality_factor (float): A multiplier which scales the infection
-            probabilities due to seasonality.
+        seasonality_factor (pandas.Series): A multiplier which scales the infection
+            probabilities due to seasonality. The index are the factor model names.
         seed (itertools.count): Seed counter to control randomness.
 
     Returns:

--- a/src/sid/contacts.py
+++ b/src/sid/contacts.py
@@ -71,7 +71,7 @@ def calculate_infections_by_contacts(
     group_codes_info: Dict[str, Dict[str, Any]],
     susceptibility_factor: np.ndarray,
     virus_strains: Dict[str, Any],
-    seasonality_factor: float,
+    seasonality_factor: pd.Series,
     seed: itertools.count,
 ) -> Tuple[pd.Series, pd.Series, pd.DataFrame]:
     """Calculate infections from contacts.
@@ -135,17 +135,17 @@ def calculate_infections_by_contacts(
         [group_codes_info[cm]["name"] for cm in random_models]
     ].to_numpy()
 
-    seasonal_infection_probabilities_recurrent = (
-        np.array(
-            [params.loc[("infection_prob", cm, cm), "value"] for cm in recurrent_models]
-        )
-        * seasonality_factor
+    seasonal_infection_probabilities_recurrent = np.array(
+        [
+            params.loc[("infection_prob", cm, cm), "value"] * seasonality_factor[cm]
+            for cm in recurrent_models
+        ]
     )
-    seasonal_infection_probabilities_random = (
-        np.array(
-            [params.loc[("infection_prob", cm, cm), "value"] for cm in random_models]
-        )
-        * seasonality_factor
+    seasonal_infection_probabilities_random = np.array(
+        [
+            params.loc[("infection_prob", cm, cm), "value"] * seasonality_factor[cm]
+            for cm in random_models
+        ]
     )
 
     infection_counter = np.zeros(len(states), dtype=DTYPE_INFECTION_COUNTER)

--- a/src/sid/covid_epi_params.csv
+++ b/src/sid/covid_epi_params.csv
@@ -34,9 +34,9 @@ cd_symptoms_true,60-69,2,0.315
 cd_symptoms_true,70-79,-1,0.31
 cd_symptoms_true,70-79,1,0.345
 cd_symptoms_true,70-79,2,0.345
-cd_symptoms_true,80-100,-1,0.31
-cd_symptoms_true,80-100,1,0.345
-cd_symptoms_true,80-100,2,0.345
+cd_symptoms_true,80-100,-1,0.25
+cd_symptoms_true,80-100,1,0.375
+cd_symptoms_true,80-100,2,0.375
 cd_symptoms_false,all,15,0.1
 cd_symptoms_false,all,18,0.3
 cd_symptoms_false,all,22,0.3

--- a/src/sid/seasonality.py
+++ b/src/sid/seasonality.py
@@ -43,7 +43,8 @@ def prepare_seasonality_factor(
             factor = pd.concat([raw_factor] * len(contact_models), axis=1)
             factor.columns = contact_models.keys()
         elif isinstance(raw_factor, pd.DataFrame):
-            factor = raw_factor.reindex(index=dates, columns=contact_models)
+            factor = pd.DataFrame(index=dates, columns=contact_models, data=1)
+            factor.update(raw_factor)
         else:
             raise ValueError(
                 "'seasonality_factor_model' must return a pd.Series or DataFrame "

--- a/src/sid/seasonality.py
+++ b/src/sid/seasonality.py
@@ -32,7 +32,7 @@ def prepare_seasonality_factor(
 
     """
     if seasonality_factor_model is None:
-        factor = pd.DataFrame(index=dates, columns=contact_models.keys(), data=1)
+        factor = pd.DataFrame(index=dates, columns=contact_models, data=1)
     else:
         raw_factor = seasonality_factor_model(
             params=params, dates=dates, seed=next(seed)
@@ -43,8 +43,7 @@ def prepare_seasonality_factor(
             factor = pd.concat([raw_factor] * len(contact_models), axis=1)
             factor.columns = contact_models.keys()
         elif isinstance(raw_factor, pd.DataFrame):
-            factor = pd.DataFrame(index=dates, columns=contact_models.keys(), data=1)
-            factor.update(raw_factor)
+            factor = raw_factor.reindex(index=dates, columns=contact_models)
         else:
             raise ValueError(
                 "'seasonality_factor_model' must return a pd.Series or DataFrame "

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -200,7 +200,10 @@ def get_simulate_func(
             returns a modified copy of contacts.
         seasonality_factor_model (Optional[Callable]): A model which takes in and
             ``params`` and ``dates`` signaling the whole duration of the simulation and
-            returns a factor for each day which scales all infection probabilities.
+            returns a DataFrame with a factor for each day and contact model which
+            scales the corresponding infection probability. If seasonality patterns are
+            the same for all contact models, the model can return a Series instead
+            of a DataFrame.
         derived_state_variables (Optional[Dict[str, str]]): A dictionary that maps
             names of state variables to pandas evaluation strings that generate derived
             state variables, i.e. state variables that can be calculated from the

--- a/src/sid/simulate.py
+++ b/src/sid/simulate.py
@@ -457,6 +457,7 @@ def _simulate(
         params=params,
         dates=duration["dates"],
         seed=seed,
+        contact_models=contact_models,
     )
 
     states = initial_states
@@ -537,7 +538,7 @@ def _simulate(
             group_codes_info=group_codes_info,
             susceptibility_factor=susceptibility_factor,
             virus_strains=virus_strains,
-            seasonality_factor=seasonality_factor[date],
+            seasonality_factor=seasonality_factor.loc[date],
             seed=seed,
         )
         (

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -77,7 +77,7 @@ def households_w_one_infected():
         "group_codes_info": group_codes_info,
         "susceptibility_factor": np.ones(len(states)),
         "virus_strains": virus_strains,
-        "seasonality_factor": 1,
+        "seasonality_factor": pd.Series([1], index=["households"]),
     }
 
 
@@ -223,7 +223,7 @@ def test_calculate_infections_only_non_recurrent(households_w_one_infected):
         group_codes_info={"non_rec": {"name": "group_codes_non_rec"}},
         susceptibility_factor=households_w_one_infected["susceptibility_factor"],
         virus_strains=households_w_one_infected["virus_strains"],
-        seasonality_factor=households_w_one_infected["seasonality_factor"],
+        seasonality_factor=pd.Series([1], index=["non_rec"]),
         seed=itertools.count(),
     )
 

--- a/tests/test_seasonality.py
+++ b/tests/test_seasonality.py
@@ -92,3 +92,26 @@ def test_prepare_seasonality_factor(
             model, params, dates, itertools.count(), contact_models
         )
         assert result.equals(expected)
+
+
+def test_prepare_seasonality_factor_with_dataframe_return():
+    def _model(params, dates, seed):
+        df = pd.DataFrame(index=dates)
+        df["households"] = [0.8, 0.8, 1]
+        df["leisure"] = [0.5, 0.5, 1]
+        return df
+
+    result = prepare_seasonality_factor(
+        seasonality_factor_model=_model,
+        params=None,
+        dates=pd.date_range("2021-04-01", "2021-04-03"),
+        seed=itertools.count(),
+        contact_models={"households": {}, "leisure": {}, "work": {}},
+    )
+    expected = pd.DataFrame(
+        data=[[0.8, 0.5, 1.0]] * 2 + [[1, 1, 1]],
+        columns=["households", "leisure", "work"],
+        index=pd.date_range("2021-04-01", "2021-04-03"),
+    )
+
+    pd.testing.assert_frame_equal(result, expected)

--- a/tests/test_seasonality.py
+++ b/tests/test_seasonality.py
@@ -38,31 +38,31 @@ def test_simulate_a_simple_model(params, initial_states, tmp_path):
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "model, params, dates, expectation, expected",
+    "model, params, dates, expectation, expected, contact_models",
     [
         pytest.param(
             None,
             None,
             pd.date_range("2020-01-01", periods=2),
             does_not_raise(),
-            pd.Series(index=pd.date_range("2020-01-01", periods=2), data=1),
+            pd.DataFrame(
+                index=pd.date_range("2020-01-01", periods=2),
+                data=1,
+                columns=["meet_two_people"],
+            ),
+            {"meet_two_people": {}},
         ),
         pytest.param(
             lambda params, dates, seed: pd.Series(index=dates, data=[1, 2, 3]),
             None,
             pd.date_range("2020-01-01", periods=3),
             does_not_raise(),
-            pd.Series(
+            pd.DataFrame(
                 index=pd.date_range("2020-01-01", periods=3),
                 data=np.array([1, 2, 3]) / 3,
+                columns=["meet_two_people"],
             ),
-        ),
-        pytest.param(
-            lambda params, dates, seed: np.ones(len(dates)),
-            None,
-            pd.date_range("2020-01-01", periods=2),
-            does_not_raise(),
-            pd.Series(index=pd.date_range("2020-01-01", periods=2), data=1.0),
+            {"meet_two_people": {}},
         ),
         pytest.param(
             lambda params, dates, seed: None,
@@ -70,6 +70,7 @@ def test_simulate_a_simple_model(params, initial_states, tmp_path):
             pd.date_range("2020-01-01", periods=2),
             pytest.raises(ValueError, match="'seasonality_factor_model'"),
             None,
+            {"meet_two_people": {}},
         ),
         pytest.param(
             lambda params, dates, seed: pd.Series(
@@ -79,10 +80,15 @@ def test_simulate_a_simple_model(params, initial_states, tmp_path):
             pd.date_range("2020-01-01", periods=2),
             pytest.raises(ValueError, match="The seasonality factors"),
             None,
+            {"meet_two_people": {}},
         ),
     ],
 )
-def test_prepare_seasonality_factor(model, params, dates, expectation, expected):
+def test_prepare_seasonality_factor(
+    model, params, dates, expectation, expected, contact_models
+):
     with expectation:
-        result = prepare_seasonality_factor(model, params, dates, itertools.count())
+        result = prepare_seasonality_factor(
+            model, params, dates, itertools.count(), contact_models
+        )
         assert result.equals(expected)


### PR DESCRIPTION
### Current behavior

All contact types have the same seasonal pattern in infectiousness.

### Desired behavior

It should be possible to have different seasonal patterns for different contact types. Examples:
- schools have weak seasonality because it always happens inside
- work contacts have slightly stronger seasonality because some things can be moved outside in the summer (construction work, meetings, lunch and coffee breaks)
- leisure contacts have very high seasonality (calibrated with mobility data for parks)

### Solution / Implementation

The `seasonality_factor_model` can return a Series (as before) or a DataFrame with contact model names in the columns. Columns for contacts with no seasonal pattern can be omitted. 

### Additional changes

- It is not allowed anymore that the `seasonality_factor_model` returns a numpy array
- Small change in epi params

- [ ] Review whether the documentation needs to be updated.
- [ ] Document PR in CHANGES.rst.
